### PR TITLE
Bugfix: Default lowest denomination

### DIFF
--- a/lib/config/app_config.dart
+++ b/lib/config/app_config.dart
@@ -46,8 +46,8 @@ class AppConfig {
       rpcBrowserUrlController: RpcBrowserUrlController(),
       defaultFeeTokenAliasModel: const TokenAliasModel(
         name: 'Kira',
-        lowestTokenDenominationModel: TokenDenominationModel(name: 'ukex', decimals: 0),
-        defaultTokenDenominationModel: TokenDenominationModel(name: 'KEX', decimals: 6),
+        defaultTokenDenominationModel: TokenDenominationModel(name: 'ukex', decimals: 0),
+        networkTokenDenominationModel: TokenDenominationModel(name: 'KEX', decimals: 6),
       ),
       defaultRefreshIntervalSeconds: 60,
       defaultNetworkUnknownModel: NetworkUnknownModel(

--- a/lib/infra/dto/shared/coin.dart
+++ b/lib/infra/dto/shared/coin.dart
@@ -13,8 +13,8 @@ class Coin extends Equatable {
 
   factory Coin.fromTokenAmountModel(TokenAmountModel tokenAmountModel) {
     return Coin(
-      denom: tokenAmountModel.tokenAliasModel.lowestTokenDenominationModel.name,
-      amount: tokenAmountModel.getAmountInLowestDenomination().toString(),
+      denom: tokenAmountModel.tokenAliasModel.defaultTokenDenominationModel.name,
+      amount: tokenAmountModel.getAmountInDefaultDenomination().toString(),
     );
   }
 

--- a/lib/infra/services/api_kira/query_balance_service.dart
+++ b/lib/infra/services/api_kira/query_balance_service.dart
@@ -75,11 +75,11 @@ class QueryBalanceService implements _IQueryBalanceService {
     List<BalanceModel> balanceModelList = List<BalanceModel>.empty(growable: true);
     for (Balance balance in queryBalanceResp.balances) {
       TokenAliasModel tokenAliasModel = tokenAliasModels.firstWhere((TokenAliasModel e) {
-        return e.lowestTokenDenominationModel.name == balance.denom;
+        return e.defaultTokenDenominationModel.name == balance.denom;
       }, orElse: () => TokenAliasModel.local(balance.denom));
 
       TokenAmountModel tokenAmountModel = TokenAmountModel(
-        lowestDenominationAmount: Decimal.parse(balance.amount),
+        defaultDenominationAmount: Decimal.parse(balance.amount),
         tokenAliasModel: tokenAliasModel,
       );
       balanceModelList.add(BalanceModel(tokenAmountModel: tokenAmountModel));

--- a/lib/infra/services/api_kira/query_execution_fee_service.dart
+++ b/lib/infra/services/api_kira/query_execution_fee_service.dart
@@ -32,7 +32,7 @@ class QueryExecutionFeeService implements _IQueryExecutionFeeService {
 
       QueryExecutionFeeResponse queryExecutionFeeResponse = QueryExecutionFeeResponse.fromJson(response.data as Map<String, dynamic>);
       TokenAmountModel feeTokenAmountModel = TokenAmountModel(
-        lowestDenominationAmount: Decimal.parse(queryExecutionFeeResponse.fee.executionFee),
+        defaultDenominationAmount: Decimal.parse(queryExecutionFeeResponse.fee.executionFee),
         // tokenAliasModel - interx doesn't return denomination used in QueryExecutionFee endpoint, so we assumed that it's always represented in "ukex"
         tokenAliasModel: _appConfig.defaultFeeTokenAliasModel,
       );

--- a/lib/shared/controllers/menu/my_account_page/balances_page/balances_filter_options.dart
+++ b/lib/shared/controllers/menu/my_account_page/balances_page/balances_filter_options.dart
@@ -10,7 +10,7 @@ class BalancesFilterOptions {
 
   static FilterOption<BalanceModel> filterBySmallValues = FilterOption<BalanceModel>(
     id: 'small',
-    filterComparator: (BalanceModel a) => a.tokenAmountModel.getAmountInDefaultDenomination() > _smallValueLimit,
+    filterComparator: (BalanceModel a) => a.tokenAmountModel.getAmountInNetworkDenomination() > _smallValueLimit,
     filterMode: FilterMode.and,
   );
 
@@ -22,7 +22,7 @@ class BalancesFilterOptions {
 
   static FilterOption<BalanceModel> filterByDerivedTokens = FilterOption<BalanceModel>(
     id: 'undelegate',
-    filterComparator: (BalanceModel a) => a.tokenAmountModel.tokenAliasModel.lowestTokenDenominationModel.name.contains('/'),
+    filterComparator: (BalanceModel a) => a.tokenAmountModel.tokenAliasModel.defaultTokenDenominationModel.name.contains('/'),
     filterMode: FilterMode.and,
   );
 
@@ -30,13 +30,13 @@ class BalancesFilterOptions {
     String pattern = searchText.toLowerCase();
 
     return (BalanceModel item) {
+      bool amountNetworkMatch = item.tokenAmountModel.getAmountInNetworkDenomination().toString().contains(pattern);
       bool amountDefaultMatch = item.tokenAmountModel.getAmountInDefaultDenomination().toString().contains(pattern);
-      bool amountLowestMatch = item.tokenAmountModel.getAmountInLowestDenomination().toString().contains(pattern);
-      bool amountMatch = amountDefaultMatch || amountLowestMatch;
+      bool amountMatch = amountNetworkMatch || amountDefaultMatch;
 
+      bool denomNetworkMatch = item.tokenAmountModel.tokenAliasModel.networkTokenDenominationModel.name.toLowerCase().contains(pattern);
       bool denomDefaultMatch = item.tokenAmountModel.tokenAliasModel.defaultTokenDenominationModel.name.toLowerCase().contains(pattern);
-      bool denomLowestMatch = item.tokenAmountModel.tokenAliasModel.lowestTokenDenominationModel.name.toLowerCase().contains(pattern);
-      bool denomMatch = denomDefaultMatch || denomLowestMatch;
+      bool denomMatch = denomNetworkMatch || denomDefaultMatch;
 
       bool nameMatch = item.tokenAmountModel.tokenAliasModel.name.toLowerCase().contains(pattern);
       return amountMatch || denomMatch || nameMatch;

--- a/lib/shared/controllers/menu/my_account_page/balances_page/balances_list_controller.dart
+++ b/lib/shared/controllers/menu/my_account_page/balances_page/balances_list_controller.dart
@@ -32,7 +32,7 @@ class BalancesListController implements IListController<BalanceModel> {
       );
 
       return balancesPageData.listItems.where((BalanceModel balanceModel) {
-        return favouriteBalances.contains(balanceModel.tokenAmountModel.tokenAliasModel.lowestTokenDenominationModel.name);
+        return favouriteBalances.contains(balanceModel.tokenAmountModel.tokenAliasModel.defaultTokenDenominationModel.name);
       }).toList();
     }
     return List<BalanceModel>.empty(growable: true);

--- a/lib/shared/controllers/menu/my_account_page/balances_page/balances_sort_options.dart
+++ b/lib/shared/controllers/menu/my_account_page/balances_page/balances_sort_options.dart
@@ -13,7 +13,7 @@ class BalancesSortOptions {
     return SortOption<BalanceModel>.asc(
       id: 'amount',
       comparator: (BalanceModel a, BalanceModel b) =>
-          a.tokenAmountModel.getAmountInDefaultDenomination().compareTo(b.tokenAmountModel.getAmountInDefaultDenomination()),
+          a.tokenAmountModel.getAmountInNetworkDenomination().compareTo(b.tokenAmountModel.getAmountInNetworkDenomination()),
     );
   }
 }

--- a/lib/shared/controllers/menu/my_account_page/staking_page/staking_filter_options.dart
+++ b/lib/shared/controllers/menu/my_account_page/staking_page/staking_filter_options.dart
@@ -7,7 +7,7 @@ class StakingFilterOptions {
     String pattern = searchText.toLowerCase();
 
     return (ValidatorStakingModel item) {
-      bool tokenMatchBool = item.tokens.map((TokenAliasModel e) => e.lowestTokenDenominationModel.name).join(' ').toLowerCase().contains(pattern);
+      bool tokenMatchBool = item.tokens.map((TokenAliasModel e) => e.defaultTokenDenominationModel.name).join(' ').toLowerCase().contains(pattern);
       bool addressMatchBool = item.validatorSimplifiedModel.walletAddress.bech32Address.toLowerCase().contains(pattern);
       bool usernameMatchBool = item.validatorSimplifiedModel.moniker?.toLowerCase().contains(pattern) ?? false;
       bool websiteMatchBool = item.validatorSimplifiedModel.website?.toLowerCase().contains(pattern) ?? false;

--- a/lib/shared/controllers/menu/my_account_page/verification_requests_list_controller/verification_requests_sort_options.dart
+++ b/lib/shared/controllers/menu/my_account_page/verification_requests_list_controller/verification_requests_sort_options.dart
@@ -13,7 +13,7 @@ class VerificationRequestsSortOptions {
     return SortOption<IRInboundVerificationRequestModel>.asc(
       id: 'tip',
       comparator: (IRInboundVerificationRequestModel a, IRInboundVerificationRequestModel b) =>
-          a.tipTokenAmountModel.getAmountInLowestDenomination().compareTo(b.tipTokenAmountModel.getAmountInLowestDenomination()),
+          a.tipTokenAmountModel.getAmountInDefaultDenomination().compareTo(b.tipTokenAmountModel.getAmountInDefaultDenomination()),
     );
   }
 }

--- a/lib/shared/models/balances/balance_model.dart
+++ b/lib/shared/models/balances/balance_model.dart
@@ -11,7 +11,7 @@ class BalanceModel extends AListItem {
   }) : _favourite = favourite;
 
   @override
-  String get cacheId => tokenAmountModel.tokenAliasModel.lowestTokenDenominationModel.name;
+  String get cacheId => tokenAmountModel.tokenAliasModel.defaultTokenDenominationModel.name;
 
   @override
   bool get isFavourite => _favourite;

--- a/lib/shared/models/network/network_properties_model.dart
+++ b/lib/shared/models/network/network_properties_model.dart
@@ -19,11 +19,11 @@ class NetworkPropertiesModel extends Equatable {
 
     return NetworkPropertiesModel(
       minTxFee: TokenAmountModel(
-        lowestDenominationAmount: Decimal.parse(properties.minTxFee),
+        defaultDenominationAmount: Decimal.parse(properties.minTxFee),
         tokenAliasModel: appConfig.defaultFeeTokenAliasModel,
       ),
       minIdentityApprovalTip: TokenAmountModel(
-        lowestDenominationAmount: Decimal.parse(properties.minIdentityApprovalTip),
+        defaultDenominationAmount: Decimal.parse(properties.minIdentityApprovalTip),
         tokenAliasModel: appConfig.defaultFeeTokenAliasModel,
       ),
     );

--- a/lib/shared/models/staking_pool/staking_pool_model.dart
+++ b/lib/shared/models/staking_pool/staking_pool_model.dart
@@ -25,7 +25,7 @@ class StakingPoolModel extends Equatable {
       totalDelegators: queryStakingPoolResp.totalDelegators,
       slashed: '${(double.parse(queryStakingPoolResp.slashed) * 100).toString()}%',
       votingPower: queryStakingPoolResp.votingPower
-          .map((Coin e) => TokenAmountModel(lowestDenominationAmount: Decimal.parse(e.amount), tokenAliasModel: TokenAliasModel.local(e.denom)))
+          .map((Coin e) => TokenAmountModel(defaultDenominationAmount: Decimal.parse(e.amount), tokenAliasModel: TokenAliasModel.local(e.denom)))
           .toList(),
       commission: '${(double.parse(queryStakingPoolResp.commission) * 100).toString()}%',
       tokens: queryStakingPoolResp.tokens.map(TokenAliasModel.local).toList(),

--- a/lib/shared/models/tokens/prefixed_token_amount_model.dart
+++ b/lib/shared/models/tokens/prefixed_token_amount_model.dart
@@ -12,11 +12,11 @@ class PrefixedTokenAmountModel extends Equatable {
   });
 
   String getAmountAsString() {
-    return '${getPrefix()}${tokenAmountModel.getAmountInLowestDenomination()}';
+    return '${getPrefix()}${tokenAmountModel.getAmountInDefaultDenomination()}';
   }
 
   String getDenominationName() {
-    return tokenAmountModel.tokenAliasModel.lowestTokenDenominationModel.name;
+    return tokenAmountModel.tokenAliasModel.defaultTokenDenominationModel.name;
   }
 
   String getPrefix() {

--- a/lib/shared/models/tokens/token_alias_model.dart
+++ b/lib/shared/models/tokens/token_alias_model.dart
@@ -4,48 +4,48 @@ import 'package:miro/shared/models/tokens/token_denomination_model.dart';
 
 class TokenAliasModel extends Equatable {
   final String name;
-  final TokenDenominationModel lowestTokenDenominationModel;
   final TokenDenominationModel defaultTokenDenominationModel;
+  final TokenDenominationModel networkTokenDenominationModel;
   final String? icon;
 
   const TokenAliasModel({
     required this.name,
-    required this.lowestTokenDenominationModel,
-    TokenDenominationModel? defaultTokenDenominationModel,
+    required this.defaultTokenDenominationModel,
+    TokenDenominationModel? networkTokenDenominationModel,
     this.icon,
-  }) : defaultTokenDenominationModel = defaultTokenDenominationModel ?? lowestTokenDenominationModel;
+  }) : networkTokenDenominationModel = networkTokenDenominationModel ?? defaultTokenDenominationModel;
 
   factory TokenAliasModel.local(String name) {
     return TokenAliasModel(
       name: name,
-      lowestTokenDenominationModel: TokenDenominationModel(name: name, decimals: 0),
+      defaultTokenDenominationModel: TokenDenominationModel(name: name, decimals: 0),
     );
   }
 
   factory TokenAliasModel.fromDto(TokenAlias tokenAlias) {
-    TokenDenominationModel defaultTokenDenominationModel = TokenDenominationModel(
+    TokenDenominationModel networkTokenDenominationModel = TokenDenominationModel(
       name: tokenAlias.symbol,
       decimals: tokenAlias.decimals,
     );
-    TokenDenominationModel lowestTokenDenominationModel =
-        tokenAlias.denoms.isNotEmpty ? TokenDenominationModel(name: tokenAlias.denoms.first, decimals: 0) : defaultTokenDenominationModel;
+    TokenDenominationModel defaultTokenDenominationModel =
+        tokenAlias.denoms.isNotEmpty ? TokenDenominationModel(name: tokenAlias.denoms.first, decimals: 0) : networkTokenDenominationModel;
 
     return TokenAliasModel(
       name: tokenAlias.name,
       icon: tokenAlias.icon,
+      networkTokenDenominationModel: networkTokenDenominationModel,
       defaultTokenDenominationModel: defaultTokenDenominationModel,
-      lowestTokenDenominationModel: lowestTokenDenominationModel,
     );
   }
 
   List<TokenDenominationModel> get tokenDenominations {
     Set<TokenDenominationModel> availableTokenDenominationModelSet = <TokenDenominationModel>{
       defaultTokenDenominationModel,
-      lowestTokenDenominationModel,
+      networkTokenDenominationModel,
     };
     return availableTokenDenominationModelSet.toList();
   }
 
   @override
-  List<Object?> get props => <Object>[lowestTokenDenominationModel];
+  List<Object?> get props => <Object>[defaultTokenDenominationModel];
 }

--- a/lib/shared/models/tokens/token_amount_model.dart
+++ b/lib/shared/models/tokens/token_amount_model.dart
@@ -4,20 +4,20 @@ import 'package:miro/shared/models/tokens/token_denomination_model.dart';
 
 class TokenAmountModel {
   final TokenAliasModel tokenAliasModel;
-  late Decimal _lowestDenominationAmount;
+  late Decimal _defaultDenominationAmount;
 
   TokenAmountModel({
-    required Decimal lowestDenominationAmount,
+    required Decimal defaultDenominationAmount,
     required this.tokenAliasModel,
   }) {
-    if (lowestDenominationAmount < Decimal.zero) {
-      _lowestDenominationAmount = Decimal.fromInt(-1);
+    if (defaultDenominationAmount < Decimal.zero) {
+      _defaultDenominationAmount = Decimal.fromInt(-1);
     } else {
-      _lowestDenominationAmount = lowestDenominationAmount;
+      _defaultDenominationAmount = defaultDenominationAmount;
     }
   }
 
-  TokenAmountModel.zero({required this.tokenAliasModel}) : _lowestDenominationAmount = Decimal.zero;
+  TokenAmountModel.zero({required this.tokenAliasModel}) : _defaultDenominationAmount = Decimal.zero;
 
   factory TokenAmountModel.fromString(String value) {
     RegExp regExpPattern = RegExp(r'(\d+)([a-zA-Z0-9/]+)');
@@ -27,37 +27,37 @@ class TokenAmountModel {
     String denom = regExpMatch.group(2)!;
 
     return TokenAmountModel(
-      lowestDenominationAmount: amount,
+      defaultDenominationAmount: amount,
       tokenAliasModel: TokenAliasModel.local(denom),
     );
   }
 
   TokenAmountModel copy() {
     return TokenAmountModel(
-      lowestDenominationAmount: _lowestDenominationAmount,
+      defaultDenominationAmount: _defaultDenominationAmount,
       tokenAliasModel: tokenAliasModel,
     );
   }
 
   int compareTo(TokenAmountModel tokenAmountModel) {
-    return tokenAmountModel._lowestDenominationAmount.compareTo(_lowestDenominationAmount);
-  }
-
-  Decimal getAmountInLowestDenomination() {
-    return _lowestDenominationAmount;
+    return tokenAmountModel._defaultDenominationAmount.compareTo(_defaultDenominationAmount);
   }
 
   Decimal getAmountInDefaultDenomination() {
-    return getAmountInDenomination(tokenAliasModel.defaultTokenDenominationModel);
+    return _defaultDenominationAmount;
+  }
+
+  Decimal getAmountInNetworkDenomination() {
+    return getAmountInDenomination(tokenAliasModel.networkTokenDenominationModel);
   }
 
   Decimal getAmountInDenomination(TokenDenominationModel tokenDenominationModel) {
-    bool isLowestTokenDenomination = tokenDenominationModel == tokenAliasModel.lowestTokenDenominationModel;
-    if (isLowestTokenDenomination) {
-      return _lowestDenominationAmount;
+    bool defaultTokenDenominationBool = tokenDenominationModel == tokenAliasModel.defaultTokenDenominationModel;
+    if (defaultTokenDenominationBool) {
+      return _defaultDenominationAmount;
     }
-    int decimalsDifference = tokenAliasModel.lowestTokenDenominationModel.decimals - tokenDenominationModel.decimals;
-    Decimal calculatedAmount = _lowestDenominationAmount.shift(decimalsDifference);
+    int decimalsDifference = tokenAliasModel.defaultTokenDenominationModel.decimals - tokenDenominationModel.decimals;
+    Decimal calculatedAmount = _defaultDenominationAmount.shift(decimalsDifference);
     return calculatedAmount;
   }
 
@@ -65,14 +65,14 @@ class TokenAmountModel {
     if (amount < Decimal.zero) {
       throw ArgumentError('Amount must be greater than zero');
     }
-    TokenDenominationModel lowestTokenDenomination = tokenAliasModel.lowestTokenDenominationModel;
+    TokenDenominationModel defaultTokenDenomination = tokenAliasModel.defaultTokenDenominationModel;
 
-    bool isLowestTokenDenomination = tokenDenominationModel == null || tokenDenominationModel == lowestTokenDenomination;
-    if (isLowestTokenDenomination) {
-      _lowestDenominationAmount = amount;
+    bool defaultTokenDenominationBool = tokenDenominationModel == null || tokenDenominationModel == defaultTokenDenomination;
+    if (defaultTokenDenominationBool) {
+      _defaultDenominationAmount = amount;
     } else {
-      int decimalsDifference = tokenDenominationModel.decimals - lowestTokenDenomination.decimals;
-      _lowestDenominationAmount = amount.shift(decimalsDifference);
+      int decimalsDifference = tokenDenominationModel.decimals - defaultTokenDenomination.decimals;
+      _defaultDenominationAmount = amount.shift(decimalsDifference);
     }
   }
 
@@ -80,9 +80,9 @@ class TokenAmountModel {
     if (tokenAmountModel.tokenAliasModel != tokenAliasModel) {
       return this;
     }
-    Decimal newAmount = _lowestDenominationAmount + tokenAmountModel._lowestDenominationAmount;
+    Decimal newAmount = _defaultDenominationAmount + tokenAmountModel._defaultDenominationAmount;
     return TokenAmountModel(
-      lowestDenominationAmount: newAmount,
+      defaultDenominationAmount: newAmount,
       tokenAliasModel: tokenAliasModel,
     );
   }
@@ -91,9 +91,9 @@ class TokenAmountModel {
     if (tokenAmountModel.tokenAliasModel != tokenAliasModel) {
       return this;
     }
-    Decimal newAmount = _lowestDenominationAmount - tokenAmountModel._lowestDenominationAmount;
+    Decimal newAmount = _defaultDenominationAmount - tokenAmountModel._defaultDenominationAmount;
     return TokenAmountModel(
-      lowestDenominationAmount: newAmount < Decimal.zero ? Decimal.zero : newAmount,
+      defaultDenominationAmount: newAmount < Decimal.zero ? Decimal.zero : newAmount,
       tokenAliasModel: tokenAliasModel,
     );
   }
@@ -103,14 +103,14 @@ class TokenAmountModel {
       identical(this, other) ||
       other is TokenAmountModel &&
           runtimeType == other.runtimeType &&
-          _lowestDenominationAmount == other._lowestDenominationAmount &&
+          _defaultDenominationAmount == other._defaultDenominationAmount &&
           tokenAliasModel == other.tokenAliasModel;
 
   @override
-  int get hashCode => _lowestDenominationAmount.hashCode ^ tokenAliasModel.hashCode;
+  int get hashCode => _defaultDenominationAmount.hashCode ^ tokenAliasModel.hashCode;
 
   @override
   String toString() {
-    return '${_lowestDenominationAmount} ${tokenAliasModel.lowestTokenDenominationModel.name}';
+    return '${_defaultDenominationAmount} ${tokenAliasModel.defaultTokenDenominationModel.name}';
   }
 }

--- a/lib/shared/models/tokens/token_denomination_model.dart
+++ b/lib/shared/models/tokens/token_denomination_model.dart
@@ -9,7 +9,7 @@ class TokenDenominationModel extends Equatable {
   /// Example KEX, uKEX
   final String name;
 
-  /// Contains decimal number from lowest token denomination
+  /// Contains decimal number from default (lowest) token denomination
   /// Example: decimals for uKEX equals 0 and for KEX equals 8
   final int decimals;
 

--- a/lib/shared/models/transactions/form_models/ir_msg_request_verification_form_model.dart
+++ b/lib/shared/models/transactions/form_models/ir_msg_request_verification_form_model.dart
@@ -52,7 +52,7 @@ class IRMsgRequestVerificationFormModel extends AMsgFormModel {
   @override
   bool canBuildTxMsg() {
     bool fieldsFilledBool = _tipTokenAmountModel != null && _requesterWalletAddress != null && _verifierWalletAddress != null;
-    bool tipAmountNotEmptyBool = _tipTokenAmountModel?.getAmountInDefaultDenomination() != Decimal.zero;
+    bool tipAmountNotEmptyBool = _tipTokenAmountModel?.getAmountInNetworkDenomination() != Decimal.zero;
     return fieldsFilledBool && tipAmountNotEmptyBool;
   }
 

--- a/lib/shared/models/transactions/form_models/msg_send_form_model.dart
+++ b/lib/shared/models/transactions/form_models/msg_send_form_model.dart
@@ -46,7 +46,7 @@ class MsgSendFormModel extends AMsgFormModel {
   @override
   bool canBuildTxMsg() {
     bool fieldsFilledBool = _senderWalletAddress != null && _recipientWalletAddress != null && _tokenAmountModel != null;
-    bool tokenAmountNotEmptyBool = _tokenAmountModel?.getAmountInDefaultDenomination() != Decimal.zero;
+    bool tokenAmountNotEmptyBool = _tokenAmountModel?.getAmountInNetworkDenomination() != Decimal.zero;
     if (fieldsFilledBool && tokenAmountNotEmptyBool) {
       return true;
     } else {

--- a/lib/shared/models/transactions/form_models/staking_msg_delegate_form_model.dart
+++ b/lib/shared/models/transactions/form_models/staking_msg_delegate_form_model.dart
@@ -49,7 +49,7 @@ class StakingMsgDelegateFormModel extends AMsgFormModel {
 
   @override
   bool canBuildTxMsg() {
-    bool amountZeroBool = tokenAmountModels?.length == 1 && tokenAmountModels?.first.getAmountInLowestDenomination() == Decimal.zero;
+    bool amountZeroBool = tokenAmountModels?.length == 1 && tokenAmountModels?.first.getAmountInDefaultDenomination() == Decimal.zero;
     bool fieldsFilledBool = _delegatorWalletAddress != null && _valoperWalletAddress != null && tokenAmountModels != null && amountZeroBool == false;
     return fieldsFilledBool;
   }

--- a/lib/shared/models/transactions/form_models/staking_msg_undelegate_form_model.dart
+++ b/lib/shared/models/transactions/form_models/staking_msg_undelegate_form_model.dart
@@ -49,7 +49,7 @@ class StakingMsgUndelegateFormModel extends AMsgFormModel {
 
   @override
   bool canBuildTxMsg() {
-    bool amountZeroBool = tokenAmountModels?.length == 1 && tokenAmountModels?.first.getAmountInLowestDenomination() == Decimal.zero;
+    bool amountZeroBool = tokenAmountModels?.length == 1 && tokenAmountModels?.first.getAmountInDefaultDenomination() == Decimal.zero;
     bool fieldsFilledBool = _delegatorWalletAddress != null && _valoperWalletAddress != null && tokenAmountModels != null && amountZeroBool == false;
     return fieldsFilledBool;
   }

--- a/lib/shared/models/transactions/list/tx_list_item_model.dart
+++ b/lib/shared/models/transactions/list/tx_list_item_model.dart
@@ -48,7 +48,7 @@ class TxListItemModel extends AListItem with EquatableMixin {
       txMsgModels: txMsgModels,
       prefixedTokenAmounts: txMsgModels.expand((ATxMsgModel txMsgModel) => txMsgModel.getPrefixedTokenAmounts(txDirectionType)).toList(),
       fees: transaction.fee
-          .map((Coin fee) => TokenAmountModel(lowestDenominationAmount: Decimal.parse(fee.amount), tokenAliasModel: TokenAliasModel.local(fee.denom)))
+          .map((Coin fee) => TokenAmountModel(defaultDenominationAmount: Decimal.parse(fee.amount), tokenAliasModel: TokenAliasModel.local(fee.denom)))
           .toList(),
     );
   }

--- a/lib/shared/models/transactions/messages/identity_registrar/ir_msg_request_verification_model.dart
+++ b/lib/shared/models/transactions/messages/identity_registrar/ir_msg_request_verification_model.dart
@@ -37,7 +37,7 @@ class IRMsgRequestVerificationModel extends ATxMsgModel {
     return IRMsgRequestVerificationModel(
       recordIds: msgRequestIdentityRecordsVerify.recordIds,
       tipTokenAmountModel: TokenAmountModel(
-        lowestDenominationAmount: Decimal.parse(msgRequestIdentityRecordsVerify.tip.amount),
+        defaultDenominationAmount: Decimal.parse(msgRequestIdentityRecordsVerify.tip.amount),
         tokenAliasModel: TokenAliasModel.local(msgRequestIdentityRecordsVerify.tip.denom),
       ),
       verifierWalletAddress: WalletAddress.fromBech32(msgRequestIdentityRecordsVerify.verifier),

--- a/lib/shared/models/transactions/messages/msg_send_model.dart
+++ b/lib/shared/models/transactions/messages/msg_send_model.dart
@@ -31,7 +31,7 @@ class MsgSendModel extends ATxMsgModel {
       fromWalletAddress: WalletAddress.fromBech32(msgSend.fromAddress),
       toWalletAddress: WalletAddress.fromBech32(msgSend.toAddress),
       tokenAmountModel: TokenAmountModel(
-        lowestDenominationAmount: Decimal.parse(msgSend.amount.first.amount),
+        defaultDenominationAmount: Decimal.parse(msgSend.amount.first.amount),
         tokenAliasModel: TokenAliasModel.local(msgSend.amount.first.denom),
       ),
     );
@@ -44,8 +44,8 @@ class MsgSendModel extends ATxMsgModel {
       toAddress: toWalletAddress.bech32Address,
       amount: <Coin>[
         Coin(
-          denom: tokenAmountModel.tokenAliasModel.lowestTokenDenominationModel.name,
-          amount: tokenAmountModel.getAmountInLowestDenomination().toString(),
+          denom: tokenAmountModel.tokenAliasModel.defaultTokenDenominationModel.name,
+          amount: tokenAmountModel.getAmountInDefaultDenomination().toString(),
         ),
       ],
     );

--- a/lib/shared/models/transactions/messages/staking/staking_msg_delegate_model.dart
+++ b/lib/shared/models/transactions/messages/staking/staking_msg_delegate_model.dart
@@ -37,7 +37,7 @@ class StakingMsgDelegateModel extends ATxMsgModel {
       valoperWalletAddress: WalletAddress.fromBech32(msgDelegate.valoperAddress),
       tokenAmountModels: msgDelegate.amounts
           .map((Coin coin) => TokenAmountModel(
-                lowestDenominationAmount: Decimal.parse(coin.amount),
+                defaultDenominationAmount: Decimal.parse(coin.amount),
                 tokenAliasModel: TokenAliasModel.local(coin.denom),
               ))
           .toList(),
@@ -51,8 +51,8 @@ class StakingMsgDelegateModel extends ATxMsgModel {
       valoperAddress: valoperWalletAddress.bech32Address,
       amounts: tokenAmountModels.map((TokenAmountModel tokenAmountModel) {
         return Coin(
-          denom: tokenAmountModel.tokenAliasModel.lowestTokenDenominationModel.name,
-          amount: tokenAmountModel.getAmountInLowestDenomination().toString(),
+          denom: tokenAmountModel.tokenAliasModel.defaultTokenDenominationModel.name,
+          amount: tokenAmountModel.getAmountInDefaultDenomination().toString(),
         );
       }).toList(),
     );

--- a/lib/shared/models/transactions/messages/staking/staking_msg_undelegate_model.dart
+++ b/lib/shared/models/transactions/messages/staking/staking_msg_undelegate_model.dart
@@ -37,7 +37,7 @@ class StakingMsgUndelegateModel extends ATxMsgModel {
       valoperWalletAddress: WalletAddress.fromBech32(msgUndelegate.valoperAddress),
       tokenAmountModels: msgUndelegate.amounts
           .map((Coin coin) => TokenAmountModel(
-                lowestDenominationAmount: Decimal.parse(coin.amount),
+                defaultDenominationAmount: Decimal.parse(coin.amount),
                 tokenAliasModel: TokenAliasModel.local(coin.denom),
               ))
           .toList(),
@@ -51,8 +51,8 @@ class StakingMsgUndelegateModel extends ATxMsgModel {
       valoperAddress: valoperWalletAddress.bech32Address,
       amounts: tokenAmountModels.map((TokenAmountModel tokenAmountModel) {
         return Coin(
-          denom: tokenAmountModel.tokenAliasModel.lowestTokenDenominationModel.name,
-          amount: tokenAmountModel.getAmountInLowestDenomination().toString(),
+          denom: tokenAmountModel.tokenAliasModel.defaultTokenDenominationModel.name,
+          amount: tokenAmountModel.getAmountInDefaultDenomination().toString(),
         );
       }).toList(),
     );

--- a/lib/shared/models/undelegations/undelegation_model.dart
+++ b/lib/shared/models/undelegations/undelegation_model.dart
@@ -32,7 +32,7 @@ class UndelegationModel extends AListItem {
       ),
       tokens: undelegation.tokens
           .map((Coin e) => TokenAmountModel(
-                lowestDenominationAmount: Decimal.parse(e.amount),
+                defaultDenominationAmount: Decimal.parse(e.amount),
                 tokenAliasModel: TokenAliasModel.local(e.denom),
               ))
           .toList(),

--- a/lib/test/mock_app_config.dart
+++ b/lib/test/mock_app_config.dart
@@ -38,8 +38,8 @@ class MockAppConfig extends AppConfig {
       rpcBrowserUrlController: RpcBrowserUrlController(),
       defaultFeeTokenAliasModel: const TokenAliasModel(
         name: 'Kira',
-        lowestTokenDenominationModel: TokenDenominationModel(name: 'ukex', decimals: 0),
-        defaultTokenDenominationModel: TokenDenominationModel(name: 'KEX', decimals: 6),
+        defaultTokenDenominationModel: TokenDenominationModel(name: 'ukex', decimals: 0),
+        networkTokenDenominationModel: TokenDenominationModel(name: 'KEX', decimals: 6),
       ),
       defaultRefreshIntervalSeconds: 60,
       defaultNetworkUnknownModel: NetworkUnknownModel(

--- a/lib/test/utils/test_utils.dart
+++ b/lib/test/utils/test_utils.dart
@@ -25,25 +25,25 @@ class TestUtils {
 
   static TokenAliasModel btcTokenAliasModel = const TokenAliasModel(
     name: 'Bitcoin',
-    lowestTokenDenominationModel: TokenDenominationModel(name: 'satoshi', decimals: 0),
-    defaultTokenDenominationModel: TokenDenominationModel(name: 'BTC', decimals: 8),
+    defaultTokenDenominationModel: TokenDenominationModel(name: 'satoshi', decimals: 0),
+    networkTokenDenominationModel: TokenDenominationModel(name: 'BTC', decimals: 8),
   );
 
   static TokenAliasModel ethTokenAliasModel = const TokenAliasModel(
     name: 'Ethereum',
-    lowestTokenDenominationModel: TokenDenominationModel(name: 'wei', decimals: 0),
-    defaultTokenDenominationModel: TokenDenominationModel(name: 'ETH', decimals: 18),
+    defaultTokenDenominationModel: TokenDenominationModel(name: 'wei', decimals: 0),
+    networkTokenDenominationModel: TokenDenominationModel(name: 'ETH', decimals: 18),
   );
 
   static TokenAliasModel kexTokenAliasModel = const TokenAliasModel(
     name: 'Kira',
-    lowestTokenDenominationModel: TokenDenominationModel(name: 'ukex', decimals: 0),
-    defaultTokenDenominationModel: TokenDenominationModel(name: 'KEX', decimals: 6),
+    defaultTokenDenominationModel: TokenDenominationModel(name: 'ukex', decimals: 0),
+    networkTokenDenominationModel: TokenDenominationModel(name: 'KEX', decimals: 6),
   );
 
   static TokenAliasModel derivedKexTokenAliasModel = const TokenAliasModel(
     name: 'v1/Kira',
-    lowestTokenDenominationModel: TokenDenominationModel(name: 'v1/ukex', decimals: 0),
+    defaultTokenDenominationModel: TokenDenominationModel(name: 'v1/ukex', decimals: 0),
   );
 
   static final NetworkUnknownModel healthyNetworkUnknownModel = NetworkUnknownModel(

--- a/lib/views/pages/menu/my_account_page/balance_page/balance_list_item/desktop/balance_list_item_desktop_expansion.dart
+++ b/lib/views/pages/menu/my_account_page/balance_page/balance_list_item/desktop/balance_list_item_desktop_expansion.dart
@@ -30,7 +30,7 @@ class BalanceListItemDesktopExpansion extends StatelessWidget {
           child: PrefixedWidget(
             prefix: S.of(context).balancesDenomination,
             child: Text(
-              tokenAmountModel.tokenAliasModel.lowestTokenDenominationModel.name,
+              tokenAmountModel.tokenAliasModel.defaultTokenDenominationModel.name,
               style: textTheme.titleMedium!.copyWith(
                 color: DesignColors.white2,
               ),
@@ -43,7 +43,7 @@ class BalanceListItemDesktopExpansion extends StatelessWidget {
           child: PrefixedWidget(
             prefix: S.of(context).balancesAmount,
             child: Text(
-              tokenAmountModel.getAmountInLowestDenomination().toString(),
+              tokenAmountModel.getAmountInDefaultDenomination().toString(),
               style: textTheme.titleMedium!.copyWith(
                 color: DesignColors.white2,
               ),

--- a/lib/views/pages/menu/my_account_page/balance_page/balance_list_item/desktop/balance_list_item_desktop_title.dart
+++ b/lib/views/pages/menu/my_account_page/balance_page/balance_list_item/desktop/balance_list_item_desktop_title.dart
@@ -42,7 +42,7 @@ class BalanceListItemDesktopTitle extends StatelessWidget {
         SizedBox(width: sectionsSpace),
         Expanded(
           child: Text(
-            balanceModel.tokenAmountModel.tokenAliasModel.defaultTokenDenominationModel.name,
+            balanceModel.tokenAmountModel.tokenAliasModel.networkTokenDenominationModel.name,
             style: textTheme.bodyLarge!.copyWith(
               color: DesignColors.white2,
             ),
@@ -52,7 +52,7 @@ class BalanceListItemDesktopTitle extends StatelessWidget {
         Expanded(
           flex: 2,
           child: Text(
-            balanceModel.tokenAmountModel.getAmountInDefaultDenomination().toString(),
+            balanceModel.tokenAmountModel.getAmountInNetworkDenomination().toString(),
             style: textTheme.titleMedium!.copyWith(
               color: DesignColors.white1,
             ),

--- a/lib/views/pages/menu/my_account_page/balance_page/balance_list_item/mobile/balance_list_item_mobile_expansion.dart
+++ b/lib/views/pages/menu/my_account_page/balance_page/balance_list_item/mobile/balance_list_item_mobile_expansion.dart
@@ -25,7 +25,7 @@ class BalanceListItemMobileExpansion extends StatelessWidget {
           PrefixedWidget(
             prefix: S.of(context).balancesDenomination,
             child: Text(
-              tokenAmountModel.tokenAliasModel.lowestTokenDenominationModel.name,
+              tokenAmountModel.tokenAliasModel.defaultTokenDenominationModel.name,
               style: textTheme.titleMedium!.copyWith(
                 color: DesignColors.white1,
               ),

--- a/lib/views/pages/menu/my_account_page/balance_page/balance_list_item/mobile/balance_list_item_mobile_title.dart
+++ b/lib/views/pages/menu/my_account_page/balance_page/balance_list_item/mobile/balance_list_item_mobile_title.dart
@@ -36,7 +36,7 @@ class BalanceListItemMobileTitle extends StatelessWidget {
           crossAxisAlignment: CrossAxisAlignment.start,
           children: <Widget>[
             Text(
-              balanceModel.tokenAmountModel.tokenAliasModel.defaultTokenDenominationModel.name,
+              balanceModel.tokenAmountModel.tokenAliasModel.networkTokenDenominationModel.name,
               style: textTheme.bodyLarge!.copyWith(
                 color: DesignColors.white1,
               ),
@@ -44,7 +44,7 @@ class BalanceListItemMobileTitle extends StatelessWidget {
             const SizedBox(width: 10),
             Expanded(
               child: Text(
-                balanceModel.tokenAmountModel.getAmountInDefaultDenomination().toString(),
+                balanceModel.tokenAmountModel.getAmountInNetworkDenomination().toString(),
                 style: textTheme.bodyLarge!.copyWith(
                   color: DesignColors.white1,
                 ),

--- a/lib/views/pages/transactions/msg_forms/ir_msg_handle_verification_request_form/ir_msg_handle_verification_request_form_preview.dart
+++ b/lib/views/pages/transactions/msg_forms/ir_msg_handle_verification_request_form/ir_msg_handle_verification_request_form_preview.dart
@@ -41,7 +41,7 @@ class _IRMsgHandleVerificationRequestFormPreview extends State<IRMsgHandleVerifi
   late final IRInboundVerificationRequestModel irInboundVerificationRequestModel =
       widget.irMsgHandleVerificationRequestFormModel.irInboundVerificationRequestModel;
   late final TokenAliasModel tokenAliasModel = irInboundVerificationRequestModel.tipTokenAmountModel.tokenAliasModel;
-  late TokenDenominationModel selectedTokenDenominationModel = tokenAliasModel.defaultTokenDenominationModel;
+  late TokenDenominationModel selectedTokenDenominationModel = tokenAliasModel.networkTokenDenominationModel;
 
   @override
   Widget build(BuildContext context) {

--- a/lib/views/pages/transactions/msg_forms/ir_msg_request_verification_form/ir_msg_request_verification_form.dart
+++ b/lib/views/pages/transactions/msg_forms/ir_msg_request_verification_form/ir_msg_request_verification_form.dart
@@ -112,7 +112,7 @@ class _IRMsgRequestVerificationForm extends State<IRMsgRequestVerificationForm> 
   }
 
   String? _validateTipAmount(TokenAmountModel? tokenAmountModel) {
-    if (tokenAmountModel!.getAmountInLowestDenomination() < widget.minTipTokenAmountModel.getAmountInLowestDenomination()) {
+    if (tokenAmountModel!.getAmountInDefaultDenomination() < widget.minTipTokenAmountModel.getAmountInDefaultDenomination()) {
       return S.of(context).irTxErrorTipMustBeGreater(widget.minTipTokenAmountModel.toString());
     } else {
       return null;

--- a/lib/views/pages/transactions/msg_forms/staking_msg_claim_undelegation_form/staking_msg_claim_undelegation_form_preview.dart
+++ b/lib/views/pages/transactions/msg_forms/staking_msg_claim_undelegation_form/staking_msg_claim_undelegation_form_preview.dart
@@ -36,7 +36,7 @@ class _StakingMsgClaimUndelegationFormPreviewState extends State<StakingMsgClaim
   late final StakingMsgClaimUndelegationModel stakingMsgClaimUndelegationModel = widget.txLocalInfoModel.txMsgModel as StakingMsgClaimUndelegationModel;
   late final TokenAliasModel tokenAliasModel = widget.amountToClaim.tokenAliasModel;
 
-  late TokenDenominationModel selectedTokenDenominationModel = widget.amountToClaim.tokenAliasModel.defaultTokenDenominationModel;
+  late TokenDenominationModel selectedTokenDenominationModel = widget.amountToClaim.tokenAliasModel.networkTokenDenominationModel;
 
   @override
   Widget build(BuildContext context) {

--- a/lib/views/pages/transactions/msg_forms/staking_msg_delegate_form/staking_msg_delegate_form.dart
+++ b/lib/views/pages/transactions/msg_forms/staking_msg_delegate_form/staking_msg_delegate_form.dart
@@ -121,7 +121,7 @@ class _StakingMsgDelegateFormState extends State<StakingMsgDelegateForm> {
   void _handleTokenAmountChanged(TokenFormState tokenFormState) {
     widget.stakingMsgDelegateFormModel.balanceModel = tokenFormState.balanceModel;
     widget.stakingMsgDelegateFormModel.tokenDenominationModel = tokenFormState.tokenDenominationModel;
-    if (tokenFormState.tokenAmountModel != null && tokenFormState.tokenAmountModel?.getAmountInLowestDenomination() != Decimal.zero) {
+    if (tokenFormState.tokenAmountModel != null && tokenFormState.tokenAmountModel?.getAmountInDefaultDenomination() != Decimal.zero) {
       widget.stakingMsgDelegateFormModel.tokenAmountModels = <TokenAmountModel>[tokenFormState.tokenAmountModel!];
     } else {
       widget.stakingMsgDelegateFormModel.tokenAmountModels = null;

--- a/lib/views/pages/transactions/msg_forms/staking_msg_delegate_form/staking_msg_delegate_form_preview.dart
+++ b/lib/views/pages/transactions/msg_forms/staking_msg_delegate_form/staking_msg_delegate_form_preview.dart
@@ -68,7 +68,7 @@ class _StakingMsgDelegateFormPreviewState extends State<StakingMsgDelegateFormPr
         const SizedBox(height: 28),
         TxInputPreview(
           label: S.of(context).stakingTxTokensToStake,
-          value: '${tokenAmountModel.getAmountInDefaultDenomination()} ${tokenAmountModel.tokenAliasModel.defaultTokenDenominationModel.name}',
+          value: _netAmountText,
           icon: TokenAvatar(
             iconUrl: tokenAmountModel.tokenAliasModel.icon,
             size: 45,

--- a/lib/views/pages/transactions/msg_forms/staking_msg_undelegate_form/staking_msg_undelegate_form.dart
+++ b/lib/views/pages/transactions/msg_forms/staking_msg_undelegate_form/staking_msg_undelegate_form.dart
@@ -114,7 +114,7 @@ class _StakingMsgUndelegateFormState extends State<StakingMsgUndelegateForm> {
   void _handleTokenAmountChanged(TokenFormState tokenFormState) {
     widget.stakingMsgUndelegateFormModel.balanceModel = tokenFormState.balanceModel;
     widget.stakingMsgUndelegateFormModel.tokenDenominationModel = tokenFormState.tokenDenominationModel;
-    bool tokenAmountModelEmpty = tokenFormState.tokenAmountModel == null || tokenFormState.tokenAmountModel?.getAmountInLowestDenomination() == Decimal.zero;
+    bool tokenAmountModelEmpty = tokenFormState.tokenAmountModel == null || tokenFormState.tokenAmountModel?.getAmountInDefaultDenomination() == Decimal.zero;
     if (tokenAmountModelEmpty) {
       widget.stakingMsgUndelegateFormModel.tokenAmountModels = null;
     } else {
@@ -126,7 +126,7 @@ class _StakingMsgUndelegateFormState extends State<StakingMsgUndelegateForm> {
     String stakedTokenName = tokenFormState.tokenAmountModel!.tokenAliasModel.name;
     String basicTokenName = stakedTokenName.substring(stakedTokenName.indexOf('/') + 1);
     TokenAmountModel basicTokenAmountModel = TokenAmountModel(
-      lowestDenominationAmount: tokenFormState.tokenAmountModel!.getAmountInLowestDenomination(),
+      defaultDenominationAmount: tokenFormState.tokenAmountModel!.getAmountInDefaultDenomination(),
       tokenAliasModel: TokenAliasModel.local(basicTokenName),
     );
     widget.stakingMsgUndelegateFormModel.tokenAmountModels = <TokenAmountModel>[basicTokenAmountModel];

--- a/lib/views/pages/transactions/msg_forms/staking_msg_undelegate_form/staking_msg_undelegate_form_preview.dart
+++ b/lib/views/pages/transactions/msg_forms/staking_msg_undelegate_form/staking_msg_undelegate_form_preview.dart
@@ -86,7 +86,7 @@ class _StakingMsgUndelegateFormPreviewState extends State<StakingMsgUndelegateFo
               child: TxInputPreview(
                 label: S.of(context).txUnstakedLabel,
                 labelColor: DesignColors.yellowStatus1,
-                value: '${tokenAmountModel.getAmountInDefaultDenomination()} ${tokenAmountModel.tokenAliasModel.defaultTokenDenominationModel.name}',
+                value: '${tokenAmountModel.getAmountInNetworkDenomination()} ${tokenAmountModel.tokenAliasModel.networkTokenDenominationModel.name}',
                 large: true,
               ),
             ),

--- a/lib/views/widgets/transactions/token_form/token_dropdown/token_dropdown_button.dart
+++ b/lib/views/widgets/transactions/token_form/token_dropdown/token_dropdown_button.dart
@@ -36,7 +36,7 @@ class TokenDropdownButton extends StatelessWidget {
                 ),
                 const SizedBox(width: 8),
                 Text(
-                  tokenAliasModel?.defaultTokenDenominationModel.name ?? '---',
+                  tokenAliasModel?.networkTokenDenominationModel.name ?? '---',
                   style: textTheme.bodyLarge!.copyWith(
                     color: DesignColors.white1,
                   ),

--- a/lib/views/widgets/transactions/token_form/token_dropdown/token_dropdown_list_item.dart
+++ b/lib/views/widgets/transactions/token_form/token_dropdown/token_dropdown_list_item.dart
@@ -41,7 +41,7 @@ class TokenDropdownListItem extends StatelessWidget {
         ),
       ),
       title: Text(
-        tokenAliasModel.defaultTokenDenominationModel.name,
+        tokenAliasModel.networkTokenDenominationModel.name,
         style: textTheme.titleSmall!.copyWith(
           color: DesignColors.white1,
         ),

--- a/lib/views/widgets/transactions/token_form/token_form.dart
+++ b/lib/views/widgets/transactions/token_form/token_form.dart
@@ -176,7 +176,7 @@ class _TokenForm extends State<TokenForm> {
       widget.onChanged(tokenFormState);
     } else if (tokenFormState.tokenAmountModel != null) {
       TokenFormState errorTokenFormState = tokenFormState.copyWith(
-        tokenAmountModel: TokenAmountModel(lowestDenominationAmount: Decimal.zero, tokenAliasModel: tokenFormState.tokenAmountModel!.tokenAliasModel),
+        tokenAmountModel: TokenAmountModel(defaultDenominationAmount: Decimal.zero, tokenAliasModel: tokenFormState.tokenAmountModel!.tokenAliasModel),
         tokenDenominationModel: tokenFormState.tokenDenominationModel,
       );
       widget.onChanged(errorTokenFormState);
@@ -192,8 +192,8 @@ class _TokenForm extends State<TokenForm> {
     TokenAmountModel? selectedTokenAmountModel = tokenFormState.tokenAmountModel;
     TokenAmountModel? availableTokenAmountModel = tokenFormState.availableTokenAmountModel;
 
-    Decimal selectedTokenAmount = selectedTokenAmountModel?.getAmountInLowestDenomination() ?? Decimal.zero;
-    Decimal availableTokenAmount = availableTokenAmountModel?.getAmountInLowestDenomination() ?? Decimal.zero;
+    Decimal selectedTokenAmount = selectedTokenAmountModel?.getAmountInDefaultDenomination() ?? Decimal.zero;
+    Decimal availableTokenAmount = availableTokenAmountModel?.getAmountInDefaultDenomination() ?? Decimal.zero;
 
     if (selectedTokenAmount == Decimal.zero) {
       return null;

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -12,7 +12,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 # In iOS, build-name is used as CFBundleShortVersionString while build-number used as CFBundleVersion.
 # Read more about iOS versioning at
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
-version: 1.21.2
+version: 1.21.3
 
 environment:
   sdk: ">=3.1.3"

--- a/test/integration/infra/services/api_kira/broadcast_service_test.dart
+++ b/test/integration/infra/services/api_kira/broadcast_service_test.dart
@@ -54,7 +54,7 @@ Future<void> main() async {
   // @formatter:on
 
   final TokenAmountModel feeTokenAmountModel = TokenAmountModel(
-    lowestDenominationAmount: Decimal.fromInt(200),
+    defaultDenominationAmount: Decimal.fromInt(200),
     tokenAliasModel: TokenAliasModel.local('ukex'),
   );
 
@@ -118,7 +118,7 @@ Future<void> main() async {
         txMsgModel: MsgSendModel(
           toWalletAddress: recipientWallet.address,
           fromWalletAddress: senderWallet.address,
-          tokenAmountModel: TokenAmountModel(lowestDenominationAmount: Decimal.fromInt(200), tokenAliasModel: TokenAliasModel.local('ukex')),
+          tokenAmountModel: TokenAmountModel(defaultDenominationAmount: Decimal.fromInt(200), tokenAliasModel: TokenAliasModel.local('ukex')),
         ),
       );
 
@@ -158,7 +158,7 @@ Future<void> main() async {
         txMsgModel: IRMsgRequestVerificationModel.single(
           recordId: BigInt.from(964),
           tipTokenAmountModel: TokenAmountModel(
-            lowestDenominationAmount: Decimal.fromInt(200),
+            defaultDenominationAmount: Decimal.fromInt(200),
             tokenAliasModel: TokenAliasModel.local('ukex'),
           ),
           verifierWalletAddress: recipientWallet.address,
@@ -237,7 +237,7 @@ Future<void> main() async {
           delegatorWalletAddress: senderWallet.address,
           valoperWalletAddress: WalletAddress.fromBech32('kiravaloper1c6slygj2tx7hzm0mn4qeflqpvngj73c2cw7fh7'),
           tokenAmountModel: TokenAmountModel(
-            lowestDenominationAmount: Decimal.fromInt(100),
+            defaultDenominationAmount: Decimal.fromInt(100),
             tokenAliasModel: TokenAliasModel.local('ukex'),
           ),
         ),
@@ -258,7 +258,7 @@ Future<void> main() async {
         txMsgModel: StakingMsgUndelegateModel.single(
           delegatorWalletAddress: senderWallet.address,
           valoperWalletAddress: WalletAddress.fromBech32('kiravaloper1c6slygj2tx7hzm0mn4qeflqpvngj73c2cw7fh7'),
-          tokenAmountModel: TokenAmountModel(lowestDenominationAmount: Decimal.fromInt(100), tokenAliasModel: TokenAliasModel.local('ukex')),
+          tokenAmountModel: TokenAmountModel(defaultDenominationAmount: Decimal.fromInt(100), tokenAliasModel: TokenAliasModel.local('ukex')),
         ),
       );
 

--- a/test/unit/blocs/pages/drawer/staking_drawer_page_cubit_test.dart
+++ b/test/unit/blocs/pages/drawer/staking_drawer_page_cubit_test.dart
@@ -60,7 +60,7 @@ Future<void> main() async {
           totalDelegators: 1,
           votingPower: <TokenAmountModel>[
             TokenAmountModel(
-              lowestDenominationAmount: Decimal.fromInt(100),
+              defaultDenominationAmount: Decimal.fromInt(100),
               tokenAliasModel: TokenAliasModel.local('ukex'),
             ),
           ],

--- a/test/unit/blocs/pages/drawer/validator_drawer_page_cubit_test.dart
+++ b/test/unit/blocs/pages/drawer/validator_drawer_page_cubit_test.dart
@@ -51,7 +51,7 @@ void main() {
             TokenAliasModel.local('ukex'),
             TokenAliasModel.local('xeth'),
           ],
-          votingPower: <TokenAmountModel>[TokenAmountModel(lowestDenominationAmount: Decimal.parse('100'), tokenAliasModel: TokenAliasModel.local('ukex'))],
+          votingPower: <TokenAmountModel>[TokenAmountModel(defaultDenominationAmount: Decimal.parse('100'), tokenAliasModel: TokenAliasModel.local('ukex'))],
           totalDelegators: 1,
         ),
       );

--- a/test/unit/blocs/pages/transactions/mock_data/mock_msg_form_model.dart
+++ b/test/unit/blocs/pages/transactions/mock_data/mock_msg_form_model.dart
@@ -11,7 +11,7 @@ class MockMsgFormModel extends AMsgFormModel {
     fromWalletAddress: WalletAddress.fromBech32('kira143q8vxpvuykt9pq50e6hng9s38vmy844n8k9wx'),
     toWalletAddress: WalletAddress.fromBech32('kira177lwmjyjds3cy7trers83r4pjn3dhv8zrqk9dl'),
     tokenAmountModel: TokenAmountModel(
-      lowestDenominationAmount: Decimal.parse('1'),
+      defaultDenominationAmount: Decimal.parse('1'),
       tokenAliasModel: TokenAliasModel.local('ukex'),
     ),
   );

--- a/test/unit/blocs/pages/transactions/tx_broadcast_cubit_test.dart
+++ b/test/unit/blocs/pages/transactions/tx_broadcast_cubit_test.dart
@@ -35,14 +35,14 @@ Future<void> main() async {
     txLocalInfoModel: TxLocalInfoModel(
       memo: 'Test transaction',
       feeTokenAmountModel: TokenAmountModel(
-        lowestDenominationAmount: Decimal.fromInt(100),
+        defaultDenominationAmount: Decimal.fromInt(100),
         tokenAliasModel: TokenAliasModel.local('ukex'),
       ),
       txMsgModel: MsgSendModel(
         fromWalletAddress: WalletAddress.fromBech32('kira143q8vxpvuykt9pq50e6hng9s38vmy844n8k9wx'),
         toWalletAddress: WalletAddress.fromBech32('kira177lwmjyjds3cy7trers83r4pjn3dhv8zrqk9dl'),
         tokenAmountModel: TokenAmountModel(
-          lowestDenominationAmount: Decimal.fromInt(100),
+          defaultDenominationAmount: Decimal.fromInt(100),
           tokenAliasModel: TokenAliasModel.local('ukex'),
         ),
       ),

--- a/test/unit/blocs/pages/transactions/tx_form_builder_cubit_test.dart
+++ b/test/unit/blocs/pages/transactions/tx_form_builder_cubit_test.dart
@@ -32,7 +32,7 @@ Future<void> main() async {
   await authCubit.signIn(senderWallet);
 
   TokenAmountModel feeTokenAmountModel = TokenAmountModel(
-    lowestDenominationAmount: Decimal.parse('100'),
+    defaultDenominationAmount: Decimal.parse('100'),
     tokenAliasModel: TestUtils.kexTokenAliasModel,
   );
 
@@ -40,7 +40,7 @@ Future<void> main() async {
     memo: '',
     feeTokenAmountModel: TokenAmountModel(
       tokenAliasModel: TestUtils.kexTokenAliasModel,
-      lowestDenominationAmount: Decimal.fromInt(100),
+      defaultDenominationAmount: Decimal.fromInt(100),
     ),
     txMsgModel: MockMsgFormModel.mockTxMsgModel,
   );

--- a/test/unit/blocs/pages/transactions/tx_process_cubit_test.dart
+++ b/test/unit/blocs/pages/transactions/tx_process_cubit_test.dart
@@ -34,14 +34,14 @@ void main() {
     txLocalInfoModel: TxLocalInfoModel(
       memo: 'Test transaction',
       feeTokenAmountModel: TokenAmountModel(
-        lowestDenominationAmount: Decimal.fromInt(100),
+        defaultDenominationAmount: Decimal.fromInt(100),
         tokenAliasModel: TokenAliasModel.local('ukex'),
       ),
       txMsgModel: MsgSendModel(
         fromWalletAddress: WalletAddress.fromBech32('kira143q8vxpvuykt9pq50e6hng9s38vmy844n8k9wx'),
         toWalletAddress: WalletAddress.fromBech32('kira177lwmjyjds3cy7trers83r4pjn3dhv8zrqk9dl'),
         tokenAmountModel: TokenAmountModel(
-          lowestDenominationAmount: Decimal.fromInt(100),
+          defaultDenominationAmount: Decimal.fromInt(100),
           tokenAliasModel: TokenAliasModel.local('ukex'),
         ),
       ),
@@ -81,16 +81,16 @@ void main() {
       // Assert
       expectedTxProcessState = TxProcessLoadedState(
         feeTokenAmountModel: TokenAmountModel(
-          lowestDenominationAmount: Decimal.fromInt(100),
+          defaultDenominationAmount: Decimal.fromInt(100),
           tokenAliasModel: TokenAliasModel.local('ukex'),
         ),
         networkPropertiesModel: NetworkPropertiesModel(
           minTxFee: TokenAmountModel(
-            lowestDenominationAmount: Decimal.fromInt(100),
+            defaultDenominationAmount: Decimal.fromInt(100),
             tokenAliasModel: TokenAliasModel.local('ukex'),
           ),
           minIdentityApprovalTip: TokenAmountModel(
-            lowestDenominationAmount: Decimal.fromInt(200),
+            defaultDenominationAmount: Decimal.fromInt(200),
             tokenAliasModel: TokenAliasModel.local('ukex'),
           ),
         ),
@@ -106,7 +106,7 @@ void main() {
         recipientWalletAddress: WalletAddress.fromBech32('kira177lwmjyjds3cy7trers83r4pjn3dhv8zrqk9dl'),
         senderWalletAddress: WalletAddress.fromBech32('kira143q8vxpvuykt9pq50e6hng9s38vmy844n8k9wx'),
         tokenAmountModel: TokenAmountModel(
-          lowestDenominationAmount: Decimal.fromInt(100),
+          defaultDenominationAmount: Decimal.fromInt(100),
           tokenAliasModel: TokenAliasModel.local('ukex'),
         ),
       )..memo = 'Test transaction';
@@ -133,16 +133,16 @@ void main() {
       expectedTxProcessState = TxProcessConfirmState(
         txProcessLoadedState: TxProcessLoadedState(
           feeTokenAmountModel: TokenAmountModel(
-            lowestDenominationAmount: Decimal.fromInt(100),
+            defaultDenominationAmount: Decimal.fromInt(100),
             tokenAliasModel: TokenAliasModel.local('ukex'),
           ),
           networkPropertiesModel: NetworkPropertiesModel(
             minTxFee: TokenAmountModel(
-              lowestDenominationAmount: Decimal.fromInt(100),
+              defaultDenominationAmount: Decimal.fromInt(100),
               tokenAliasModel: TokenAliasModel.local('ukex'),
             ),
             minIdentityApprovalTip: TokenAmountModel(
-              lowestDenominationAmount: Decimal.fromInt(200),
+              defaultDenominationAmount: Decimal.fromInt(200),
               tokenAliasModel: TokenAliasModel.local('ukex'),
             ),
           ),
@@ -203,16 +203,16 @@ void main() {
       // Assert
       expectedTxProcessLoadedState = TxProcessLoadedState(
         feeTokenAmountModel: TokenAmountModel(
-          lowestDenominationAmount: Decimal.fromInt(100),
+          defaultDenominationAmount: Decimal.fromInt(100),
           tokenAliasModel: TokenAliasModel.local('ukex'),
         ),
         networkPropertiesModel: NetworkPropertiesModel(
           minTxFee: TokenAmountModel(
-            lowestDenominationAmount: Decimal.fromInt(100),
+            defaultDenominationAmount: Decimal.fromInt(100),
             tokenAliasModel: TokenAliasModel.local('ukex'),
           ),
           minIdentityApprovalTip: TokenAmountModel(
-            lowestDenominationAmount: Decimal.fromInt(200),
+            defaultDenominationAmount: Decimal.fromInt(200),
             tokenAliasModel: TokenAliasModel.local('ukex'),
           ),
         ),

--- a/test/unit/blocs/widgets/transactions/token_form_cubit_test.dart
+++ b/test/unit/blocs/widgets/transactions/token_form_cubit_test.dart
@@ -16,20 +16,20 @@ Future<void> main() async {
   await initMockLocator();
 
   TokenAmountModel feeTokenAmountModel = TokenAmountModel(
-    lowestDenominationAmount: Decimal.fromInt(100),
+    defaultDenominationAmount: Decimal.fromInt(100),
     tokenAliasModel: TestUtils.kexTokenAliasModel,
   );
 
   BalanceModel kexBalanceModel = BalanceModel(
     tokenAmountModel: TokenAmountModel(
-      lowestDenominationAmount: Decimal.fromInt(1000),
+      defaultDenominationAmount: Decimal.fromInt(1000),
       tokenAliasModel: TestUtils.kexTokenAliasModel,
     ),
   );
 
   BalanceModel ethBalanceModel = BalanceModel(
     tokenAmountModel: TokenAmountModel(
-      lowestDenominationAmount: Decimal.fromInt(5000),
+      defaultDenominationAmount: Decimal.fromInt(5000),
       tokenAliasModel: TestUtils.ethTokenAliasModel,
     ),
   );
@@ -132,7 +132,7 @@ Future<void> main() async {
         feeTokenAmountModel: feeTokenAmountModel,
         balanceModel: kexBalanceModel,
         tokenAmountModel: TokenAmountModel(
-          lowestDenominationAmount: Decimal.fromInt(100000000),
+          defaultDenominationAmount: Decimal.fromInt(100),
           tokenAliasModel: TestUtils.kexTokenAliasModel,
         ),
         tokenDenominationModel: TestUtils.kexTokenAliasModel.defaultTokenDenominationModel,
@@ -146,23 +146,44 @@ Future<void> main() async {
       // ************************************************************************************************
 
       // Act
-      actualTokenFormCubit.updateTokenDenomination(TestUtils.kexTokenAliasModel.lowestTokenDenominationModel);
+      actualTokenFormCubit.updateTokenDenomination(TestUtils.kexTokenAliasModel.networkTokenDenominationModel);
 
       // Assert
       expectedTokenFormState = TokenFormState.fromBalance(
         feeTokenAmountModel: feeTokenAmountModel,
         balanceModel: kexBalanceModel,
         tokenAmountModel: TokenAmountModel(
-          lowestDenominationAmount: Decimal.fromInt(100000000),
+          defaultDenominationAmount: Decimal.fromInt(100),
           tokenAliasModel: TestUtils.kexTokenAliasModel,
         ),
-        tokenDenominationModel: TestUtils.kexTokenAliasModel.lowestTokenDenominationModel,
+        tokenDenominationModel: TestUtils.kexTokenAliasModel.networkTokenDenominationModel,
         walletAddress: TestUtils.wallet.address,
       );
 
       TestUtils.printInfo('Should [return TokenFormState] with updated TokenDenominationModel');
       expect(actualTokenFormCubit.state, expectedTokenFormState);
-      expect(actualTokenFormCubit.amountTextEditingController.text, '100000000');
+      expect(actualTokenFormCubit.amountTextEditingController.text, '0.0001');
+
+      // ************************************************************************************************
+
+      // Act
+      actualTokenFormCubit.updateTokenDenomination(TestUtils.kexTokenAliasModel.defaultTokenDenominationModel);
+
+      // Assert
+      expectedTokenFormState = TokenFormState.fromBalance(
+        feeTokenAmountModel: feeTokenAmountModel,
+        balanceModel: kexBalanceModel,
+        tokenAmountModel: TokenAmountModel(
+          defaultDenominationAmount: Decimal.fromInt(100),
+          tokenAliasModel: TestUtils.kexTokenAliasModel,
+        ),
+        tokenDenominationModel: TestUtils.kexTokenAliasModel.defaultTokenDenominationModel,
+        walletAddress: TestUtils.wallet.address,
+      );
+
+      TestUtils.printInfo('Should [return TokenFormState] with updated TokenDenominationModel');
+      expect(actualTokenFormCubit.state, expectedTokenFormState);
+      expect(actualTokenFormCubit.amountTextEditingController.text, '100');
 
       // ************************************************************************************************
 
@@ -174,10 +195,10 @@ Future<void> main() async {
         feeTokenAmountModel: feeTokenAmountModel,
         balanceModel: kexBalanceModel,
         tokenAmountModel: TokenAmountModel(
-          lowestDenominationAmount: Decimal.fromInt(900),
+          defaultDenominationAmount: Decimal.fromInt(900),
           tokenAliasModel: TestUtils.kexTokenAliasModel,
         ),
-        tokenDenominationModel: TestUtils.kexTokenAliasModel.lowestTokenDenominationModel,
+        tokenDenominationModel: TestUtils.kexTokenAliasModel.defaultTokenDenominationModel,
         walletAddress: TestUtils.wallet.address,
       );
 
@@ -194,13 +215,14 @@ Future<void> main() async {
       expectedTokenFormState = TokenFormState.fromBalance(
         feeTokenAmountModel: feeTokenAmountModel,
         balanceModel: kexBalanceModel,
-        tokenDenominationModel: TestUtils.kexTokenAliasModel.lowestTokenDenominationModel,
+        tokenDenominationModel: TestUtils.kexTokenAliasModel.defaultTokenDenominationModel,
         tokenAmountModel: TokenAmountModel.zero(tokenAliasModel: TestUtils.kexTokenAliasModel),
         walletAddress: TestUtils.wallet.address,
       );
 
       TestUtils.printInfo('Should [return TokenFormState] with cleared token amount');
       expect(actualTokenFormCubit.state, expectedTokenFormState);
+      expect(actualTokenFormCubit.amountTextEditingController.text, '0');
 
       // ************************************************************************************************
 
@@ -213,10 +235,10 @@ Future<void> main() async {
         feeTokenAmountModel: feeTokenAmountModel,
         balanceModel: kexBalanceModel,
         tokenAmountModel: TokenAmountModel(
-          lowestDenominationAmount: Decimal.fromInt(100),
+          defaultDenominationAmount: Decimal.fromInt(100),
           tokenAliasModel: TestUtils.kexTokenAliasModel,
         ),
-        tokenDenominationModel: TestUtils.kexTokenAliasModel.lowestTokenDenominationModel,
+        tokenDenominationModel: TestUtils.kexTokenAliasModel.defaultTokenDenominationModel,
         walletAddress: TestUtils.wallet.address,
       );
 

--- a/test/unit/infra/services/api/query_transactions_service_test.dart
+++ b/test/unit/infra/services/api/query_transactions_service_test.dart
@@ -50,19 +50,19 @@ Future<void> main() async {
         txDirectionType: TxDirectionType.outbound,
         txStatusType: TxStatusType.confirmed,
         fees: <TokenAmountModel>[
-          TokenAmountModel(lowestDenominationAmount: Decimal.fromInt(100), tokenAliasModel: TokenAliasModel.local('ukex')),
+          TokenAmountModel(defaultDenominationAmount: Decimal.fromInt(100), tokenAliasModel: TokenAliasModel.local('ukex')),
         ],
         prefixedTokenAmounts: <PrefixedTokenAmountModel>[
           PrefixedTokenAmountModel(
             tokenAmountPrefixType: TokenAmountPrefixType.subtract,
-            tokenAmountModel: TokenAmountModel(lowestDenominationAmount: Decimal.fromInt(100), tokenAliasModel: TokenAliasModel.local('samolean')),
+            tokenAmountModel: TokenAmountModel(defaultDenominationAmount: Decimal.fromInt(100), tokenAliasModel: TokenAliasModel.local('samolean')),
           ),
         ],
         txMsgModels: <ATxMsgModel>[
           MsgSendModel(
             fromWalletAddress: WalletAddress.fromBech32('kira143q8vxpvuykt9pq50e6hng9s38vmy844n8k9wx'),
             toWalletAddress: WalletAddress.fromBech32('kira177lwmjyjds3cy7trers83r4pjn3dhv8zrqk9dl'),
-            tokenAmountModel: TokenAmountModel(lowestDenominationAmount: Decimal.fromInt(100), tokenAliasModel: TokenAliasModel.local('samolean')),
+            tokenAmountModel: TokenAmountModel(defaultDenominationAmount: Decimal.fromInt(100), tokenAliasModel: TokenAliasModel.local('samolean')),
           ),
         ],
       ),
@@ -73,19 +73,19 @@ Future<void> main() async {
         txDirectionType: TxDirectionType.inbound,
         txStatusType: TxStatusType.confirmed,
         fees: <TokenAmountModel>[
-          TokenAmountModel(lowestDenominationAmount: Decimal.fromInt(500), tokenAliasModel: TokenAliasModel.local('ukex')),
+          TokenAmountModel(defaultDenominationAmount: Decimal.fromInt(500), tokenAliasModel: TokenAliasModel.local('ukex')),
         ],
         prefixedTokenAmounts: <PrefixedTokenAmountModel>[
           PrefixedTokenAmountModel(
             tokenAmountPrefixType: TokenAmountPrefixType.add,
-            tokenAmountModel: TokenAmountModel(lowestDenominationAmount: Decimal.fromInt(20000000), tokenAliasModel: TokenAliasModel.local('test')),
+            tokenAmountModel: TokenAmountModel(defaultDenominationAmount: Decimal.fromInt(20000000), tokenAliasModel: TokenAliasModel.local('test')),
           ),
         ],
         txMsgModels: <ATxMsgModel>[
           MsgSendModel(
             fromWalletAddress: WalletAddress.fromBech32('kira1m82gva4kqj28ulnk02a8447uumdl26jyegsca4'),
             toWalletAddress: WalletAddress.fromBech32('kira143q8vxpvuykt9pq50e6hng9s38vmy844n8k9wx'),
-            tokenAmountModel: TokenAmountModel(lowestDenominationAmount: Decimal.fromInt(20000000), tokenAliasModel: TokenAliasModel.local('test')),
+            tokenAmountModel: TokenAmountModel(defaultDenominationAmount: Decimal.fromInt(20000000), tokenAliasModel: TokenAliasModel.local('test')),
           ),
         ],
       ),
@@ -96,7 +96,7 @@ Future<void> main() async {
         txDirectionType: TxDirectionType.outbound,
         txStatusType: TxStatusType.confirmed,
         fees: <TokenAmountModel>[
-          TokenAmountModel(lowestDenominationAmount: Decimal.fromInt(200), tokenAliasModel: TokenAliasModel.local('ukex')),
+          TokenAmountModel(defaultDenominationAmount: Decimal.fromInt(200), tokenAliasModel: TokenAliasModel.local('ukex')),
         ],
         prefixedTokenAmounts: <PrefixedTokenAmountModel>[],
         txMsgModels: <ATxMsgModel>[
@@ -115,18 +115,18 @@ Future<void> main() async {
         txDirectionType: TxDirectionType.outbound,
         txStatusType: TxStatusType.confirmed,
         fees: <TokenAmountModel>[
-          TokenAmountModel(lowestDenominationAmount: Decimal.fromInt(200), tokenAliasModel: TokenAliasModel.local('ukex')),
+          TokenAmountModel(defaultDenominationAmount: Decimal.fromInt(200), tokenAliasModel: TokenAliasModel.local('ukex')),
         ],
         prefixedTokenAmounts: <PrefixedTokenAmountModel>[
           PrefixedTokenAmountModel(
             tokenAmountPrefixType: TokenAmountPrefixType.subtract,
-            tokenAmountModel: TokenAmountModel(lowestDenominationAmount: Decimal.fromInt(200), tokenAliasModel: TokenAliasModel.local('ukex')),
+            tokenAmountModel: TokenAmountModel(defaultDenominationAmount: Decimal.fromInt(200), tokenAliasModel: TokenAliasModel.local('ukex')),
           ),
         ],
         txMsgModels: <ATxMsgModel>[
           IRMsgRequestVerificationModel(
             recordIds: <BigInt>[BigInt.from(2)],
-            tipTokenAmountModel: TokenAmountModel(lowestDenominationAmount: Decimal.fromInt(200), tokenAliasModel: TokenAliasModel.local('ukex')),
+            tipTokenAmountModel: TokenAmountModel(defaultDenominationAmount: Decimal.fromInt(200), tokenAliasModel: TokenAliasModel.local('ukex')),
             verifierWalletAddress: WalletAddress.fromBech32('kira177lwmjyjds3cy7trers83r4pjn3dhv8zrqk9dl'),
             walletAddress: WalletAddress.fromBech32('kira143q8vxpvuykt9pq50e6hng9s38vmy844n8k9wx'),
           ),
@@ -139,7 +139,7 @@ Future<void> main() async {
         txDirectionType: TxDirectionType.outbound,
         txStatusType: TxStatusType.confirmed,
         fees: <TokenAmountModel>[
-          TokenAmountModel(lowestDenominationAmount: Decimal.fromInt(200), tokenAliasModel: TokenAliasModel.local('ukex')),
+          TokenAmountModel(defaultDenominationAmount: Decimal.fromInt(200), tokenAliasModel: TokenAliasModel.local('ukex')),
         ],
         prefixedTokenAmounts: <PrefixedTokenAmountModel>[],
         txMsgModels: <ATxMsgModel>[
@@ -156,7 +156,7 @@ Future<void> main() async {
         txDirectionType: TxDirectionType.outbound,
         txStatusType: TxStatusType.confirmed,
         fees: <TokenAmountModel>[
-          TokenAmountModel(lowestDenominationAmount: Decimal.fromInt(200), tokenAliasModel: TokenAliasModel.local('ukex')),
+          TokenAmountModel(defaultDenominationAmount: Decimal.fromInt(200), tokenAliasModel: TokenAliasModel.local('ukex')),
         ],
         prefixedTokenAmounts: <PrefixedTokenAmountModel>[],
         txMsgModels: <ATxMsgModel>[
@@ -173,7 +173,7 @@ Future<void> main() async {
         txDirectionType: TxDirectionType.outbound,
         txStatusType: TxStatusType.confirmed,
         fees: <TokenAmountModel>[
-          TokenAmountModel(lowestDenominationAmount: Decimal.fromInt(200), tokenAliasModel: TokenAliasModel.local('ukex')),
+          TokenAmountModel(defaultDenominationAmount: Decimal.fromInt(200), tokenAliasModel: TokenAliasModel.local('ukex')),
         ],
         prefixedTokenAmounts: <PrefixedTokenAmountModel>[],
         txMsgModels: <ATxMsgModel>[
@@ -195,18 +195,18 @@ Future<void> main() async {
             delegatorWalletAddress: WalletAddress.fromBech32('kira143q8vxpvuykt9pq50e6hng9s38vmy844n8k9wx'),
             valoperWalletAddress: WalletAddress.fromBech32('kiravaloper1c6slygj2tx7hzm0mn4qeflqpvngj73c2cw7fh7'),
             tokenAmountModels: <TokenAmountModel>[
-              TokenAmountModel(lowestDenominationAmount: Decimal.fromInt(100), tokenAliasModel: TokenAliasModel.local('ukex'))
+              TokenAmountModel(defaultDenominationAmount: Decimal.fromInt(100), tokenAliasModel: TokenAliasModel.local('ukex'))
             ],
           ),
         ],
         prefixedTokenAmounts: <PrefixedTokenAmountModel>[
           PrefixedTokenAmountModel(
             tokenAmountPrefixType: TokenAmountPrefixType.subtract,
-            tokenAmountModel: TokenAmountModel(lowestDenominationAmount: Decimal.fromInt(100), tokenAliasModel: TokenAliasModel.local('ukex')),
+            tokenAmountModel: TokenAmountModel(defaultDenominationAmount: Decimal.fromInt(100), tokenAliasModel: TokenAliasModel.local('ukex')),
           ),
         ],
         fees: <TokenAmountModel>[
-          TokenAmountModel(lowestDenominationAmount: Decimal.fromInt(100), tokenAliasModel: TokenAliasModel.local('ukex')),
+          TokenAmountModel(defaultDenominationAmount: Decimal.fromInt(100), tokenAliasModel: TokenAliasModel.local('ukex')),
         ],
       ),
       // MsgUndelegate
@@ -220,18 +220,18 @@ Future<void> main() async {
             delegatorWalletAddress: WalletAddress.fromBech32('kira143q8vxpvuykt9pq50e6hng9s38vmy844n8k9wx'),
             valoperWalletAddress: WalletAddress.fromBech32('kiravaloper1c6slygj2tx7hzm0mn4qeflqpvngj73c2cw7fh7'),
             tokenAmountModels: <TokenAmountModel>[
-              TokenAmountModel(lowestDenominationAmount: Decimal.fromInt(100), tokenAliasModel: TokenAliasModel.local('ukex'))
+              TokenAmountModel(defaultDenominationAmount: Decimal.fromInt(100), tokenAliasModel: TokenAliasModel.local('ukex'))
             ],
           ),
         ],
         prefixedTokenAmounts: <PrefixedTokenAmountModel>[
           PrefixedTokenAmountModel(
             tokenAmountPrefixType: TokenAmountPrefixType.add,
-            tokenAmountModel: TokenAmountModel(lowestDenominationAmount: Decimal.fromInt(100), tokenAliasModel: TokenAliasModel.local('ukex')),
+            tokenAmountModel: TokenAmountModel(defaultDenominationAmount: Decimal.fromInt(100), tokenAliasModel: TokenAliasModel.local('ukex')),
           ),
         ],
         fees: <TokenAmountModel>[
-          TokenAmountModel(lowestDenominationAmount: Decimal.fromInt(100), tokenAliasModel: TokenAliasModel.local('ukex')),
+          TokenAmountModel(defaultDenominationAmount: Decimal.fromInt(100), tokenAliasModel: TokenAliasModel.local('ukex')),
         ],
       ),
       // MsgClaimRewards
@@ -243,7 +243,7 @@ Future<void> main() async {
         txMsgModels: <ATxMsgModel>[StakingMsgClaimRewardsModel(senderWalletAddress: WalletAddress.fromBech32('kira143q8vxpvuykt9pq50e6hng9s38vmy844n8k9wx'))],
         prefixedTokenAmounts: <PrefixedTokenAmountModel>[],
         fees: <TokenAmountModel>[
-          TokenAmountModel(lowestDenominationAmount: Decimal.fromInt(100), tokenAliasModel: TokenAliasModel.local('ukex')),
+          TokenAmountModel(defaultDenominationAmount: Decimal.fromInt(100), tokenAliasModel: TokenAliasModel.local('ukex')),
         ],
       ),
       // MsgClaimUndelegation
@@ -260,7 +260,7 @@ Future<void> main() async {
         ],
         prefixedTokenAmounts: <PrefixedTokenAmountModel>[],
         fees: <TokenAmountModel>[
-          TokenAmountModel(lowestDenominationAmount: Decimal.fromInt(100), tokenAliasModel: TokenAliasModel.local('ukex')),
+          TokenAmountModel(defaultDenominationAmount: Decimal.fromInt(100), tokenAliasModel: TokenAliasModel.local('ukex')),
         ],
       ),
     ],

--- a/test/unit/infra/services/api_kira/broadcast_service_test.dart
+++ b/test/unit/infra/services/api_kira/broadcast_service_test.dart
@@ -62,7 +62,7 @@ Future<void> main() async {
   // @formatter:on
 
   final TokenAmountModel feeTokenAmountModel = TokenAmountModel(
-    lowestDenominationAmount: Decimal.fromInt(200),
+    defaultDenominationAmount: Decimal.fromInt(200),
     tokenAliasModel: TokenAliasModel.local('ukex'),
   );
 
@@ -104,7 +104,7 @@ Future<void> main() async {
         txMsgModel: MsgSendModel(
           toWalletAddress: recipientWallet.address,
           fromWalletAddress: senderWallet.address,
-          tokenAmountModel: TokenAmountModel(lowestDenominationAmount: Decimal.fromInt(200), tokenAliasModel: TokenAliasModel.local('ukex')),
+          tokenAmountModel: TokenAmountModel(defaultDenominationAmount: Decimal.fromInt(200), tokenAliasModel: TokenAliasModel.local('ukex')),
         ),
       );
 
@@ -275,7 +275,7 @@ Future<void> main() async {
         txMsgModel: IRMsgRequestVerificationModel.single(
           recordId: BigInt.from(964),
           tipTokenAmountModel: TokenAmountModel(
-            lowestDenominationAmount: Decimal.fromInt(200),
+            defaultDenominationAmount: Decimal.fromInt(200),
             tokenAliasModel: TokenAliasModel.local('ukex'),
           ),
           verifierWalletAddress: recipientWallet.address,
@@ -605,7 +605,7 @@ Future<void> main() async {
           delegatorWalletAddress: senderWallet.address,
           valoperWalletAddress: WalletAddress.fromBech32('kiravaloper1c6slygj2tx7hzm0mn4qeflqpvngj73c2cw7fh7'),
           tokenAmountModel: TokenAmountModel(
-            lowestDenominationAmount: Decimal.fromInt(100),
+            defaultDenominationAmount: Decimal.fromInt(100),
             tokenAliasModel: TokenAliasModel.local('ukex'),
           ),
         ),
@@ -696,7 +696,7 @@ Future<void> main() async {
           delegatorWalletAddress: senderWallet.address,
           valoperWalletAddress: WalletAddress.fromBech32('kiravaloper1c6slygj2tx7hzm0mn4qeflqpvngj73c2cw7fh7'),
           tokenAmountModel: TokenAmountModel(
-            lowestDenominationAmount: Decimal.fromInt(100),
+            defaultDenominationAmount: Decimal.fromInt(100),
             tokenAliasModel: TokenAliasModel.local('ukex'),
           ),
         ),

--- a/test/unit/infra/services/api_kira/query_balance_service_test.dart
+++ b/test/unit/infra/services/api_kira/query_balance_service_test.dart
@@ -29,25 +29,25 @@ Future<void> main() async {
     listItems: <BalanceModel>[
       BalanceModel(
         tokenAmountModel: TokenAmountModel(
-          lowestDenominationAmount: Decimal.parse('9878'),
+          defaultDenominationAmount: Decimal.parse('9878'),
           tokenAliasModel: TokenAliasModel.local('lol'),
         ),
       ),
       BalanceModel(
         tokenAmountModel: TokenAmountModel(
-          lowestDenominationAmount: Decimal.parse('90000000000000000000000000'),
+          defaultDenominationAmount: Decimal.parse('90000000000000000000000000'),
           tokenAliasModel: TokenAliasModel.local('samolean'),
         ),
       ),
       BalanceModel(
         tokenAmountModel: TokenAmountModel(
-          lowestDenominationAmount: Decimal.parse('199779999999631'),
+          defaultDenominationAmount: Decimal.parse('199779999999631'),
           tokenAliasModel: TokenAliasModel.local('test'),
         ),
       ),
       BalanceModel(
         tokenAmountModel: TokenAmountModel(
-          lowestDenominationAmount: Decimal.parse('856916'),
+          defaultDenominationAmount: Decimal.parse('856916'),
           tokenAliasModel: TokenAliasModel.local('ukex'),
         ),
       ),

--- a/test/unit/infra/services/api_kira/query_execution_fee_service_test.dart
+++ b/test/unit/infra/services/api_kira/query_execution_fee_service_test.dart
@@ -31,7 +31,7 @@ Future<void> main() async {
 
       // Assert
       TokenAmountModel expectedTokenAmountModel = TokenAmountModel(
-        lowestDenominationAmount: Decimal.parse('100'),
+        defaultDenominationAmount: Decimal.parse('100'),
         tokenAliasModel: appConfig.defaultFeeTokenAliasModel,
       );
 

--- a/test/unit/infra/services/api_kira/query_network_properties_service_test.dart
+++ b/test/unit/infra/services/api_kira/query_network_properties_service_test.dart
@@ -20,8 +20,8 @@ Future<void> main() async {
 
   const TokenAliasModel defaultFeeTokenAliasModel = TokenAliasModel(
     name: 'Kira',
-    lowestTokenDenominationModel: TokenDenominationModel(name: 'ukex', decimals: 0),
-    defaultTokenDenominationModel: TokenDenominationModel(name: 'KEX', decimals: 6),
+    defaultTokenDenominationModel: TokenDenominationModel(name: 'ukex', decimals: 0),
+    networkTokenDenominationModel: TokenDenominationModel(name: 'KEX', decimals: 6),
   );
 
   group('Tests of QueryNetworkPropertiesService.getTxFee() method', () {
@@ -35,7 +35,7 @@ Future<void> main() async {
 
       // Assert
       TokenAmountModel expectedTokenAmountModel = TokenAmountModel(
-        lowestDenominationAmount: Decimal.parse('100'),
+        defaultDenominationAmount: Decimal.parse('100'),
         tokenAliasModel: defaultFeeTokenAliasModel,
       );
 

--- a/test/unit/infra/services/api_kira/query_staking_pool_service_test.dart
+++ b/test/unit/infra/services/api_kira/query_staking_pool_service_test.dart
@@ -35,7 +35,7 @@ Future<void> main() async {
         totalDelegators: 1,
         votingPower: <TokenAmountModel>[
           TokenAmountModel(
-            lowestDenominationAmount: Decimal.fromInt(100),
+            defaultDenominationAmount: Decimal.fromInt(100),
             tokenAliasModel: TokenAliasModel.local('ukex'),
           ),
         ],

--- a/test/unit/infra/services/api_kira/query_undelegations_service_test.dart
+++ b/test/unit/infra/services/api_kira/query_undelegations_service_test.dart
@@ -48,7 +48,7 @@ Future<void> main() async {
             ),
             tokens: <TokenAmountModel>[
               TokenAmountModel(
-                lowestDenominationAmount: Decimal.fromInt(2000),
+                defaultDenominationAmount: Decimal.fromInt(2000),
                 tokenAliasModel: TokenAliasModel.local('ukex'),
               ),
             ],

--- a/test/unit/shared/controllers/menu/my_acount_page/balances_page/balances_filter_options_test.dart
+++ b/test/unit/shared/controllers/menu/my_acount_page/balances_page/balances_filter_options_test.dart
@@ -13,19 +13,19 @@ void main() {
   initMockLocator();
   // @formatter:off
   List<BalanceModel> balanceModelsList = <BalanceModel>[
-    BalanceModel(tokenAmountModel: TokenAmountModel(tokenAliasModel: TestUtils.kexTokenAliasModel, lowestDenominationAmount: Decimal.fromInt(2000000))),
-    BalanceModel(tokenAmountModel: TokenAmountModel(tokenAliasModel: TestUtils.kexTokenAliasModel, lowestDenominationAmount: Decimal.fromInt(1))),
-    BalanceModel(tokenAmountModel: TokenAmountModel(tokenAliasModel: TestUtils.kexTokenAliasModel, lowestDenominationAmount: Decimal.fromInt(200000))),
+    BalanceModel(tokenAmountModel: TokenAmountModel(tokenAliasModel: TestUtils.kexTokenAliasModel, defaultDenominationAmount: Decimal.fromInt(2000000))),
+    BalanceModel(tokenAmountModel: TokenAmountModel(tokenAliasModel: TestUtils.kexTokenAliasModel, defaultDenominationAmount: Decimal.fromInt(1))),
+    BalanceModel(tokenAmountModel: TokenAmountModel(tokenAliasModel: TestUtils.kexTokenAliasModel, defaultDenominationAmount: Decimal.fromInt(200000))),
     //----------
-    BalanceModel(tokenAmountModel: TokenAmountModel(tokenAliasModel: TestUtils.btcTokenAliasModel, lowestDenominationAmount: Decimal.fromInt(100000))),
-    BalanceModel(tokenAmountModel: TokenAmountModel(tokenAliasModel: TestUtils.btcTokenAliasModel, lowestDenominationAmount: Decimal.fromInt(200000))),
-    BalanceModel(tokenAmountModel: TokenAmountModel(tokenAliasModel: TestUtils.btcTokenAliasModel, lowestDenominationAmount: Decimal.fromInt(300000000))),
+    BalanceModel(tokenAmountModel: TokenAmountModel(tokenAliasModel: TestUtils.btcTokenAliasModel, defaultDenominationAmount: Decimal.fromInt(100000))),
+    BalanceModel(tokenAmountModel: TokenAmountModel(tokenAliasModel: TestUtils.btcTokenAliasModel, defaultDenominationAmount: Decimal.fromInt(200000))),
+    BalanceModel(tokenAmountModel: TokenAmountModel(tokenAliasModel: TestUtils.btcTokenAliasModel, defaultDenominationAmount: Decimal.fromInt(300000000))),
     //----------
-    BalanceModel(tokenAmountModel: TokenAmountModel(tokenAliasModel: TestUtils.ethTokenAliasModel, lowestDenominationAmount: Decimal.fromInt(10000))),
-    BalanceModel(tokenAmountModel: TokenAmountModel(tokenAliasModel: TestUtils.ethTokenAliasModel, lowestDenominationAmount: Decimal.fromInt(20000))),
-    BalanceModel(tokenAmountModel: TokenAmountModel(tokenAliasModel: TestUtils.ethTokenAliasModel, lowestDenominationAmount: Decimal.fromInt(30000))),
+    BalanceModel(tokenAmountModel: TokenAmountModel(tokenAliasModel: TestUtils.ethTokenAliasModel, defaultDenominationAmount: Decimal.fromInt(10000))),
+    BalanceModel(tokenAmountModel: TokenAmountModel(tokenAliasModel: TestUtils.ethTokenAliasModel, defaultDenominationAmount: Decimal.fromInt(20000))),
+    BalanceModel(tokenAmountModel: TokenAmountModel(tokenAliasModel: TestUtils.ethTokenAliasModel, defaultDenominationAmount: Decimal.fromInt(30000))),
     //----------
-    BalanceModel(tokenAmountModel: TokenAmountModel(tokenAliasModel: TestUtils.derivedKexTokenAliasModel, lowestDenominationAmount: Decimal.fromInt(10000))),
+    BalanceModel(tokenAmountModel: TokenAmountModel(tokenAliasModel: TestUtils.derivedKexTokenAliasModel, defaultDenominationAmount: Decimal.fromInt(10000))),
   ];
   // @formatter:on
 
@@ -40,9 +40,9 @@ void main() {
       // Assert
       // @formatter:off
       List<BalanceModel> expectedBalancesList = <BalanceModel>[
-        BalanceModel(tokenAmountModel: TokenAmountModel(tokenAliasModel: TestUtils.kexTokenAliasModel, lowestDenominationAmount: Decimal.fromInt(2000000))),
-        BalanceModel(tokenAmountModel: TokenAmountModel(tokenAliasModel: TestUtils.btcTokenAliasModel, lowestDenominationAmount: Decimal.fromInt(300000000))),
-        BalanceModel(tokenAmountModel: TokenAmountModel(tokenAliasModel: TestUtils.derivedKexTokenAliasModel, lowestDenominationAmount: Decimal.fromInt(10000))),
+        BalanceModel(tokenAmountModel: TokenAmountModel(tokenAliasModel: TestUtils.kexTokenAliasModel, defaultDenominationAmount: Decimal.fromInt(2000000))),
+        BalanceModel(tokenAmountModel: TokenAmountModel(tokenAliasModel: TestUtils.btcTokenAliasModel, defaultDenominationAmount: Decimal.fromInt(300000000))),
+        BalanceModel(tokenAmountModel: TokenAmountModel(tokenAliasModel: TestUtils.derivedKexTokenAliasModel, defaultDenominationAmount: Decimal.fromInt(10000))),
       ];
       // @formatter:on
 
@@ -61,9 +61,9 @@ void main() {
       // Assert
       // @formatter:off
       List<BalanceModel> expectedBalancesList = <BalanceModel>[
-        BalanceModel(tokenAmountModel: TokenAmountModel(tokenAliasModel: TestUtils.kexTokenAliasModel, lowestDenominationAmount: Decimal.fromInt(2000000))),
-        BalanceModel(tokenAmountModel: TokenAmountModel(tokenAliasModel: TestUtils.kexTokenAliasModel, lowestDenominationAmount: Decimal.fromInt(1))),
-        BalanceModel(tokenAmountModel: TokenAmountModel(tokenAliasModel: TestUtils.kexTokenAliasModel, lowestDenominationAmount: Decimal.fromInt(200000))),
+        BalanceModel(tokenAmountModel: TokenAmountModel(tokenAliasModel: TestUtils.kexTokenAliasModel, defaultDenominationAmount: Decimal.fromInt(2000000))),
+        BalanceModel(tokenAmountModel: TokenAmountModel(tokenAliasModel: TestUtils.kexTokenAliasModel, defaultDenominationAmount: Decimal.fromInt(1))),
+        BalanceModel(tokenAmountModel: TokenAmountModel(tokenAliasModel: TestUtils.kexTokenAliasModel, defaultDenominationAmount: Decimal.fromInt(200000))),
       ];
       // @formatter:on
 
@@ -82,7 +82,7 @@ void main() {
       // Assert
       // @formatter:off
       List<BalanceModel> expectedBalancesList = <BalanceModel>[
-        BalanceModel(tokenAmountModel: TokenAmountModel(tokenAliasModel: TestUtils.derivedKexTokenAliasModel, lowestDenominationAmount: Decimal.fromInt(10000))),
+        BalanceModel(tokenAmountModel: TokenAmountModel(tokenAliasModel: TestUtils.derivedKexTokenAliasModel, defaultDenominationAmount: Decimal.fromInt(10000))),
       ];
       // @formatter:on
 
@@ -101,9 +101,9 @@ void main() {
       // Assert
       // @formatter:off
       List<BalanceModel> expectedBalancesList = <BalanceModel>[
-        BalanceModel(tokenAmountModel: TokenAmountModel(tokenAliasModel: TestUtils.btcTokenAliasModel, lowestDenominationAmount: Decimal.fromInt(100000))),
-        BalanceModel(tokenAmountModel: TokenAmountModel(tokenAliasModel: TestUtils.ethTokenAliasModel, lowestDenominationAmount: Decimal.fromInt(10000))),
-        BalanceModel(tokenAmountModel: TokenAmountModel(tokenAliasModel: TestUtils.derivedKexTokenAliasModel, lowestDenominationAmount: Decimal.fromInt(10000))),
+        BalanceModel(tokenAmountModel: TokenAmountModel(tokenAliasModel: TestUtils.btcTokenAliasModel, defaultDenominationAmount: Decimal.fromInt(100000))),
+        BalanceModel(tokenAmountModel: TokenAmountModel(tokenAliasModel: TestUtils.ethTokenAliasModel, defaultDenominationAmount: Decimal.fromInt(10000))),
+        BalanceModel(tokenAmountModel: TokenAmountModel(tokenAliasModel: TestUtils.derivedKexTokenAliasModel, defaultDenominationAmount: Decimal.fromInt(10000))),
       ];
       // @formatter:on
 
@@ -120,9 +120,9 @@ void main() {
       // Assert
       // @formatter:off
       List<BalanceModel> expectedBalancesList = <BalanceModel>[
-        BalanceModel(tokenAmountModel: TokenAmountModel(tokenAliasModel: TestUtils.ethTokenAliasModel, lowestDenominationAmount: Decimal.fromInt(10000))),
-        BalanceModel(tokenAmountModel: TokenAmountModel(tokenAliasModel: TestUtils.ethTokenAliasModel, lowestDenominationAmount: Decimal.fromInt(20000))),
-        BalanceModel(tokenAmountModel: TokenAmountModel(tokenAliasModel: TestUtils.ethTokenAliasModel, lowestDenominationAmount: Decimal.fromInt(30000))),
+        BalanceModel(tokenAmountModel: TokenAmountModel(tokenAliasModel: TestUtils.ethTokenAliasModel, defaultDenominationAmount: Decimal.fromInt(10000))),
+        BalanceModel(tokenAmountModel: TokenAmountModel(tokenAliasModel: TestUtils.ethTokenAliasModel, defaultDenominationAmount: Decimal.fromInt(20000))),
+        BalanceModel(tokenAmountModel: TokenAmountModel(tokenAliasModel: TestUtils.ethTokenAliasModel, defaultDenominationAmount: Decimal.fromInt(30000))),
       ];
       // @formatter:on
 
@@ -139,9 +139,9 @@ void main() {
       // Assert
       // @formatter:off
       List<BalanceModel> expectedBalancesList = <BalanceModel>[
-        BalanceModel(tokenAmountModel: TokenAmountModel(tokenAliasModel: TestUtils.btcTokenAliasModel, lowestDenominationAmount: Decimal.fromInt(100000))),
-        BalanceModel(tokenAmountModel: TokenAmountModel(tokenAliasModel: TestUtils.btcTokenAliasModel, lowestDenominationAmount: Decimal.fromInt(200000))),
-        BalanceModel(tokenAmountModel: TokenAmountModel(tokenAliasModel: TestUtils.btcTokenAliasModel, lowestDenominationAmount: Decimal.fromInt(300000000))),
+        BalanceModel(tokenAmountModel: TokenAmountModel(tokenAliasModel: TestUtils.btcTokenAliasModel, defaultDenominationAmount: Decimal.fromInt(100000))),
+        BalanceModel(tokenAmountModel: TokenAmountModel(tokenAliasModel: TestUtils.btcTokenAliasModel, defaultDenominationAmount: Decimal.fromInt(200000))),
+        BalanceModel(tokenAmountModel: TokenAmountModel(tokenAliasModel: TestUtils.btcTokenAliasModel, defaultDenominationAmount: Decimal.fromInt(300000000))),
       ];
       // @formatter:on
 

--- a/test/unit/shared/controllers/menu/my_acount_page/balances_page/balances_sort_options_test.dart
+++ b/test/unit/shared/controllers/menu/my_acount_page/balances_page/balances_sort_options_test.dart
@@ -7,17 +7,17 @@ import 'package:miro/test/utils/test_utils.dart';
 
 void main() {
   List<BalanceModel> balanceModelsList = <BalanceModel>[
-    BalanceModel(tokenAmountModel: TokenAmountModel(tokenAliasModel: TestUtils.kexTokenAliasModel, lowestDenominationAmount: Decimal.fromInt(2000000))),
-    BalanceModel(tokenAmountModel: TokenAmountModel(tokenAliasModel: TestUtils.kexTokenAliasModel, lowestDenominationAmount: Decimal.fromInt(1))),
-    BalanceModel(tokenAmountModel: TokenAmountModel(tokenAliasModel: TestUtils.kexTokenAliasModel, lowestDenominationAmount: Decimal.fromInt(200000))),
+    BalanceModel(tokenAmountModel: TokenAmountModel(tokenAliasModel: TestUtils.kexTokenAliasModel, defaultDenominationAmount: Decimal.fromInt(2000000))),
+    BalanceModel(tokenAmountModel: TokenAmountModel(tokenAliasModel: TestUtils.kexTokenAliasModel, defaultDenominationAmount: Decimal.fromInt(1))),
+    BalanceModel(tokenAmountModel: TokenAmountModel(tokenAliasModel: TestUtils.kexTokenAliasModel, defaultDenominationAmount: Decimal.fromInt(200000))),
     //----------
-    BalanceModel(tokenAmountModel: TokenAmountModel(tokenAliasModel: TestUtils.btcTokenAliasModel, lowestDenominationAmount: Decimal.fromInt(100000))),
-    BalanceModel(tokenAmountModel: TokenAmountModel(tokenAliasModel: TestUtils.btcTokenAliasModel, lowestDenominationAmount: Decimal.fromInt(200000))),
-    BalanceModel(tokenAmountModel: TokenAmountModel(tokenAliasModel: TestUtils.btcTokenAliasModel, lowestDenominationAmount: Decimal.fromInt(300000000))),
+    BalanceModel(tokenAmountModel: TokenAmountModel(tokenAliasModel: TestUtils.btcTokenAliasModel, defaultDenominationAmount: Decimal.fromInt(100000))),
+    BalanceModel(tokenAmountModel: TokenAmountModel(tokenAliasModel: TestUtils.btcTokenAliasModel, defaultDenominationAmount: Decimal.fromInt(200000))),
+    BalanceModel(tokenAmountModel: TokenAmountModel(tokenAliasModel: TestUtils.btcTokenAliasModel, defaultDenominationAmount: Decimal.fromInt(300000000))),
     //----------
-    BalanceModel(tokenAmountModel: TokenAmountModel(tokenAliasModel: TestUtils.ethTokenAliasModel, lowestDenominationAmount: Decimal.fromInt(10000))),
-    BalanceModel(tokenAmountModel: TokenAmountModel(tokenAliasModel: TestUtils.ethTokenAliasModel, lowestDenominationAmount: Decimal.fromInt(20000))),
-    BalanceModel(tokenAmountModel: TokenAmountModel(tokenAliasModel: TestUtils.ethTokenAliasModel, lowestDenominationAmount: Decimal.fromInt(30000))),
+    BalanceModel(tokenAmountModel: TokenAmountModel(tokenAliasModel: TestUtils.ethTokenAliasModel, defaultDenominationAmount: Decimal.fromInt(10000))),
+    BalanceModel(tokenAmountModel: TokenAmountModel(tokenAliasModel: TestUtils.ethTokenAliasModel, defaultDenominationAmount: Decimal.fromInt(20000))),
+    BalanceModel(tokenAmountModel: TokenAmountModel(tokenAliasModel: TestUtils.ethTokenAliasModel, defaultDenominationAmount: Decimal.fromInt(30000))),
   ];
 
   group('Tests of BalancesSortOptions.sortByDenom', () {
@@ -27,17 +27,17 @@ void main() {
 
       // Assert
       List<BalanceModel> expectedBalancesList = <BalanceModel>[
-        BalanceModel(tokenAmountModel: TokenAmountModel(tokenAliasModel: TestUtils.btcTokenAliasModel, lowestDenominationAmount: Decimal.fromInt(100000))),
-        BalanceModel(tokenAmountModel: TokenAmountModel(tokenAliasModel: TestUtils.btcTokenAliasModel, lowestDenominationAmount: Decimal.fromInt(200000))),
-        BalanceModel(tokenAmountModel: TokenAmountModel(tokenAliasModel: TestUtils.btcTokenAliasModel, lowestDenominationAmount: Decimal.fromInt(300000000))),
+        BalanceModel(tokenAmountModel: TokenAmountModel(tokenAliasModel: TestUtils.btcTokenAliasModel, defaultDenominationAmount: Decimal.fromInt(100000))),
+        BalanceModel(tokenAmountModel: TokenAmountModel(tokenAliasModel: TestUtils.btcTokenAliasModel, defaultDenominationAmount: Decimal.fromInt(200000))),
+        BalanceModel(tokenAmountModel: TokenAmountModel(tokenAliasModel: TestUtils.btcTokenAliasModel, defaultDenominationAmount: Decimal.fromInt(300000000))),
         //----------
-        BalanceModel(tokenAmountModel: TokenAmountModel(tokenAliasModel: TestUtils.ethTokenAliasModel, lowestDenominationAmount: Decimal.fromInt(10000))),
-        BalanceModel(tokenAmountModel: TokenAmountModel(tokenAliasModel: TestUtils.ethTokenAliasModel, lowestDenominationAmount: Decimal.fromInt(20000))),
-        BalanceModel(tokenAmountModel: TokenAmountModel(tokenAliasModel: TestUtils.ethTokenAliasModel, lowestDenominationAmount: Decimal.fromInt(30000))),
+        BalanceModel(tokenAmountModel: TokenAmountModel(tokenAliasModel: TestUtils.ethTokenAliasModel, defaultDenominationAmount: Decimal.fromInt(10000))),
+        BalanceModel(tokenAmountModel: TokenAmountModel(tokenAliasModel: TestUtils.ethTokenAliasModel, defaultDenominationAmount: Decimal.fromInt(20000))),
+        BalanceModel(tokenAmountModel: TokenAmountModel(tokenAliasModel: TestUtils.ethTokenAliasModel, defaultDenominationAmount: Decimal.fromInt(30000))),
         //----------
-        BalanceModel(tokenAmountModel: TokenAmountModel(tokenAliasModel: TestUtils.kexTokenAliasModel, lowestDenominationAmount: Decimal.fromInt(2000000))),
-        BalanceModel(tokenAmountModel: TokenAmountModel(tokenAliasModel: TestUtils.kexTokenAliasModel, lowestDenominationAmount: Decimal.fromInt(1))),
-        BalanceModel(tokenAmountModel: TokenAmountModel(tokenAliasModel: TestUtils.kexTokenAliasModel, lowestDenominationAmount: Decimal.fromInt(200000))),
+        BalanceModel(tokenAmountModel: TokenAmountModel(tokenAliasModel: TestUtils.kexTokenAliasModel, defaultDenominationAmount: Decimal.fromInt(2000000))),
+        BalanceModel(tokenAmountModel: TokenAmountModel(tokenAliasModel: TestUtils.kexTokenAliasModel, defaultDenominationAmount: Decimal.fromInt(1))),
+        BalanceModel(tokenAmountModel: TokenAmountModel(tokenAliasModel: TestUtils.kexTokenAliasModel, defaultDenominationAmount: Decimal.fromInt(200000))),
       ];
 
       expect(actualBalancesList, expectedBalancesList);
@@ -49,17 +49,17 @@ void main() {
 
       // Assert
       List<BalanceModel> expectedBalancesList = <BalanceModel>[
-        BalanceModel(tokenAmountModel: TokenAmountModel(tokenAliasModel: TestUtils.kexTokenAliasModel, lowestDenominationAmount: Decimal.fromInt(2000000))),
-        BalanceModel(tokenAmountModel: TokenAmountModel(tokenAliasModel: TestUtils.kexTokenAliasModel, lowestDenominationAmount: Decimal.fromInt(1))),
-        BalanceModel(tokenAmountModel: TokenAmountModel(tokenAliasModel: TestUtils.kexTokenAliasModel, lowestDenominationAmount: Decimal.fromInt(200000))),
+        BalanceModel(tokenAmountModel: TokenAmountModel(tokenAliasModel: TestUtils.kexTokenAliasModel, defaultDenominationAmount: Decimal.fromInt(2000000))),
+        BalanceModel(tokenAmountModel: TokenAmountModel(tokenAliasModel: TestUtils.kexTokenAliasModel, defaultDenominationAmount: Decimal.fromInt(1))),
+        BalanceModel(tokenAmountModel: TokenAmountModel(tokenAliasModel: TestUtils.kexTokenAliasModel, defaultDenominationAmount: Decimal.fromInt(200000))),
         //----------
-        BalanceModel(tokenAmountModel: TokenAmountModel(tokenAliasModel: TestUtils.ethTokenAliasModel, lowestDenominationAmount: Decimal.fromInt(10000))),
-        BalanceModel(tokenAmountModel: TokenAmountModel(tokenAliasModel: TestUtils.ethTokenAliasModel, lowestDenominationAmount: Decimal.fromInt(20000))),
-        BalanceModel(tokenAmountModel: TokenAmountModel(tokenAliasModel: TestUtils.ethTokenAliasModel, lowestDenominationAmount: Decimal.fromInt(30000))),
+        BalanceModel(tokenAmountModel: TokenAmountModel(tokenAliasModel: TestUtils.ethTokenAliasModel, defaultDenominationAmount: Decimal.fromInt(10000))),
+        BalanceModel(tokenAmountModel: TokenAmountModel(tokenAliasModel: TestUtils.ethTokenAliasModel, defaultDenominationAmount: Decimal.fromInt(20000))),
+        BalanceModel(tokenAmountModel: TokenAmountModel(tokenAliasModel: TestUtils.ethTokenAliasModel, defaultDenominationAmount: Decimal.fromInt(30000))),
         //----------
-        BalanceModel(tokenAmountModel: TokenAmountModel(tokenAliasModel: TestUtils.btcTokenAliasModel, lowestDenominationAmount: Decimal.fromInt(100000))),
-        BalanceModel(tokenAmountModel: TokenAmountModel(tokenAliasModel: TestUtils.btcTokenAliasModel, lowestDenominationAmount: Decimal.fromInt(200000))),
-        BalanceModel(tokenAmountModel: TokenAmountModel(tokenAliasModel: TestUtils.btcTokenAliasModel, lowestDenominationAmount: Decimal.fromInt(300000000))),
+        BalanceModel(tokenAmountModel: TokenAmountModel(tokenAliasModel: TestUtils.btcTokenAliasModel, defaultDenominationAmount: Decimal.fromInt(100000))),
+        BalanceModel(tokenAmountModel: TokenAmountModel(tokenAliasModel: TestUtils.btcTokenAliasModel, defaultDenominationAmount: Decimal.fromInt(200000))),
+        BalanceModel(tokenAmountModel: TokenAmountModel(tokenAliasModel: TestUtils.btcTokenAliasModel, defaultDenominationAmount: Decimal.fromInt(300000000))),
       ];
 
       expect(actualBalancesList, expectedBalancesList);
@@ -73,15 +73,15 @@ void main() {
 
       // Assert
       List<BalanceModel> expectedBalancesList = <BalanceModel>[
-        BalanceModel(tokenAmountModel: TokenAmountModel(tokenAliasModel: TestUtils.ethTokenAliasModel, lowestDenominationAmount: Decimal.fromInt(10000))),
-        BalanceModel(tokenAmountModel: TokenAmountModel(tokenAliasModel: TestUtils.ethTokenAliasModel, lowestDenominationAmount: Decimal.fromInt(20000))),
-        BalanceModel(tokenAmountModel: TokenAmountModel(tokenAliasModel: TestUtils.ethTokenAliasModel, lowestDenominationAmount: Decimal.fromInt(30000))),
-        BalanceModel(tokenAmountModel: TokenAmountModel(tokenAliasModel: TestUtils.kexTokenAliasModel, lowestDenominationAmount: Decimal.fromInt(1))),
-        BalanceModel(tokenAmountModel: TokenAmountModel(tokenAliasModel: TestUtils.btcTokenAliasModel, lowestDenominationAmount: Decimal.fromInt(100000))),
-        BalanceModel(tokenAmountModel: TokenAmountModel(tokenAliasModel: TestUtils.btcTokenAliasModel, lowestDenominationAmount: Decimal.fromInt(200000))),
-        BalanceModel(tokenAmountModel: TokenAmountModel(tokenAliasModel: TestUtils.kexTokenAliasModel, lowestDenominationAmount: Decimal.fromInt(200000))),
-        BalanceModel(tokenAmountModel: TokenAmountModel(tokenAliasModel: TestUtils.kexTokenAliasModel, lowestDenominationAmount: Decimal.fromInt(2000000))),
-        BalanceModel(tokenAmountModel: TokenAmountModel(tokenAliasModel: TestUtils.btcTokenAliasModel, lowestDenominationAmount: Decimal.fromInt(300000000))),
+        BalanceModel(tokenAmountModel: TokenAmountModel(tokenAliasModel: TestUtils.ethTokenAliasModel, defaultDenominationAmount: Decimal.fromInt(10000))),
+        BalanceModel(tokenAmountModel: TokenAmountModel(tokenAliasModel: TestUtils.ethTokenAliasModel, defaultDenominationAmount: Decimal.fromInt(20000))),
+        BalanceModel(tokenAmountModel: TokenAmountModel(tokenAliasModel: TestUtils.ethTokenAliasModel, defaultDenominationAmount: Decimal.fromInt(30000))),
+        BalanceModel(tokenAmountModel: TokenAmountModel(tokenAliasModel: TestUtils.kexTokenAliasModel, defaultDenominationAmount: Decimal.fromInt(1))),
+        BalanceModel(tokenAmountModel: TokenAmountModel(tokenAliasModel: TestUtils.btcTokenAliasModel, defaultDenominationAmount: Decimal.fromInt(100000))),
+        BalanceModel(tokenAmountModel: TokenAmountModel(tokenAliasModel: TestUtils.btcTokenAliasModel, defaultDenominationAmount: Decimal.fromInt(200000))),
+        BalanceModel(tokenAmountModel: TokenAmountModel(tokenAliasModel: TestUtils.kexTokenAliasModel, defaultDenominationAmount: Decimal.fromInt(200000))),
+        BalanceModel(tokenAmountModel: TokenAmountModel(tokenAliasModel: TestUtils.kexTokenAliasModel, defaultDenominationAmount: Decimal.fromInt(2000000))),
+        BalanceModel(tokenAmountModel: TokenAmountModel(tokenAliasModel: TestUtils.btcTokenAliasModel, defaultDenominationAmount: Decimal.fromInt(300000000))),
       ];
 
       expect(actualBalancesList, expectedBalancesList);
@@ -93,15 +93,15 @@ void main() {
 
       // Assert
       List<BalanceModel> expectedBalancesList = <BalanceModel>[
-        BalanceModel(tokenAmountModel: TokenAmountModel(tokenAliasModel: TestUtils.btcTokenAliasModel, lowestDenominationAmount: Decimal.fromInt(300000000))),
-        BalanceModel(tokenAmountModel: TokenAmountModel(tokenAliasModel: TestUtils.kexTokenAliasModel, lowestDenominationAmount: Decimal.fromInt(2000000))),
-        BalanceModel(tokenAmountModel: TokenAmountModel(tokenAliasModel: TestUtils.kexTokenAliasModel, lowestDenominationAmount: Decimal.fromInt(200000))),
-        BalanceModel(tokenAmountModel: TokenAmountModel(tokenAliasModel: TestUtils.btcTokenAliasModel, lowestDenominationAmount: Decimal.fromInt(200000))),
-        BalanceModel(tokenAmountModel: TokenAmountModel(tokenAliasModel: TestUtils.btcTokenAliasModel, lowestDenominationAmount: Decimal.fromInt(100000))),
-        BalanceModel(tokenAmountModel: TokenAmountModel(tokenAliasModel: TestUtils.kexTokenAliasModel, lowestDenominationAmount: Decimal.fromInt(1))),
-        BalanceModel(tokenAmountModel: TokenAmountModel(tokenAliasModel: TestUtils.ethTokenAliasModel, lowestDenominationAmount: Decimal.fromInt(30000))),
-        BalanceModel(tokenAmountModel: TokenAmountModel(tokenAliasModel: TestUtils.ethTokenAliasModel, lowestDenominationAmount: Decimal.fromInt(20000))),
-        BalanceModel(tokenAmountModel: TokenAmountModel(tokenAliasModel: TestUtils.ethTokenAliasModel, lowestDenominationAmount: Decimal.fromInt(10000))),
+        BalanceModel(tokenAmountModel: TokenAmountModel(tokenAliasModel: TestUtils.btcTokenAliasModel, defaultDenominationAmount: Decimal.fromInt(300000000))),
+        BalanceModel(tokenAmountModel: TokenAmountModel(tokenAliasModel: TestUtils.kexTokenAliasModel, defaultDenominationAmount: Decimal.fromInt(2000000))),
+        BalanceModel(tokenAmountModel: TokenAmountModel(tokenAliasModel: TestUtils.kexTokenAliasModel, defaultDenominationAmount: Decimal.fromInt(200000))),
+        BalanceModel(tokenAmountModel: TokenAmountModel(tokenAliasModel: TestUtils.btcTokenAliasModel, defaultDenominationAmount: Decimal.fromInt(200000))),
+        BalanceModel(tokenAmountModel: TokenAmountModel(tokenAliasModel: TestUtils.btcTokenAliasModel, defaultDenominationAmount: Decimal.fromInt(100000))),
+        BalanceModel(tokenAmountModel: TokenAmountModel(tokenAliasModel: TestUtils.kexTokenAliasModel, defaultDenominationAmount: Decimal.fromInt(1))),
+        BalanceModel(tokenAmountModel: TokenAmountModel(tokenAliasModel: TestUtils.ethTokenAliasModel, defaultDenominationAmount: Decimal.fromInt(30000))),
+        BalanceModel(tokenAmountModel: TokenAmountModel(tokenAliasModel: TestUtils.ethTokenAliasModel, defaultDenominationAmount: Decimal.fromInt(20000))),
+        BalanceModel(tokenAmountModel: TokenAmountModel(tokenAliasModel: TestUtils.ethTokenAliasModel, defaultDenominationAmount: Decimal.fromInt(10000))),
       ];
 
       expect(actualBalancesList, expectedBalancesList);

--- a/test/unit/shared/controllers/menu/my_acount_page/undelegations_page/undelegations_filter_options_test.dart
+++ b/test/unit/shared/controllers/menu/my_acount_page/undelegations_page/undelegations_filter_options_test.dart
@@ -28,7 +28,7 @@ void main() {
       validatorSimplifiedModel: validatorSimplifiedModel1,
       tokens: <TokenAmountModel>[
         TokenAmountModel(
-          lowestDenominationAmount: Decimal.fromInt(2000),
+          defaultDenominationAmount: Decimal.fromInt(2000),
           tokenAliasModel: TokenAliasModel.local('ukex'),
         ),
       ],
@@ -39,7 +39,7 @@ void main() {
       validatorSimplifiedModel: validatorSimplifiedModel2,
       tokens: <TokenAmountModel>[
         TokenAmountModel(
-          lowestDenominationAmount: Decimal.fromInt(300),
+          defaultDenominationAmount: Decimal.fromInt(300),
           tokenAliasModel: TokenAliasModel.local('samolean'),
         ),
       ],
@@ -50,7 +50,7 @@ void main() {
       validatorSimplifiedModel: validatorSimplifiedModel1,
       tokens: <TokenAmountModel>[
         TokenAmountModel(
-          lowestDenominationAmount: Decimal.fromInt(50000),
+          defaultDenominationAmount: Decimal.fromInt(50000),
           tokenAliasModel: TokenAliasModel.local('lol'),
         ),
       ],

--- a/test/unit/shared/controllers/menu/my_acount_page/undelegations_page/undelegations_sort_options_test.dart
+++ b/test/unit/shared/controllers/menu/my_acount_page/undelegations_page/undelegations_sort_options_test.dart
@@ -19,7 +19,7 @@ void main() {
       validatorSimplifiedModel: validatorSimplifiedModel,
       tokens: <TokenAmountModel>[
         TokenAmountModel(
-          lowestDenominationAmount: Decimal.fromInt(2000),
+          defaultDenominationAmount: Decimal.fromInt(2000),
           tokenAliasModel: TokenAliasModel.local('ukex'),
         ),
       ],
@@ -30,7 +30,7 @@ void main() {
       validatorSimplifiedModel: validatorSimplifiedModel,
       tokens: <TokenAmountModel>[
         TokenAmountModel(
-          lowestDenominationAmount: Decimal.fromInt(300),
+          defaultDenominationAmount: Decimal.fromInt(300),
           tokenAliasModel: TokenAliasModel.local('samolean'),
         ),
       ],
@@ -41,7 +41,7 @@ void main() {
       validatorSimplifiedModel: validatorSimplifiedModel,
       tokens: <TokenAmountModel>[
         TokenAmountModel(
-          lowestDenominationAmount: Decimal.fromInt(50000),
+          defaultDenominationAmount: Decimal.fromInt(50000),
           tokenAliasModel: TokenAliasModel.local('lol'),
         ),
       ],

--- a/test/unit/shared/controllers/menu/my_acount_page/verification_requests_page/verification_requests_filter_options_test.dart
+++ b/test/unit/shared/controllers/menu/my_acount_page/verification_requests_page/verification_requests_filter_options_test.dart
@@ -28,7 +28,7 @@ void main() {
     dateTime: DateTime(2020, 1, 1),
     requesterIrUserProfileModel: irUserProfileModel1,
     records: <String, String>{'flower': 'rose'},
-    tipTokenAmountModel: TokenAmountModel(tokenAliasModel: TestUtils.kexTokenAliasModel, lowestDenominationAmount: Decimal.fromInt(500)),
+    tipTokenAmountModel: TokenAmountModel(tokenAliasModel: TestUtils.kexTokenAliasModel, defaultDenominationAmount: Decimal.fromInt(500)),
   );
 
   final IRInboundVerificationRequestModel irInboundVerificationRequestModel2 = IRInboundVerificationRequestModel(
@@ -36,7 +36,7 @@ void main() {
     dateTime: DateTime(2021, 1, 1),
     requesterIrUserProfileModel: irUserProfileModel2,
     records: <String, String>{'username': 'miroman123'},
-    tipTokenAmountModel: TokenAmountModel(tokenAliasModel: TestUtils.kexTokenAliasModel, lowestDenominationAmount: Decimal.fromInt(10000)),
+    tipTokenAmountModel: TokenAmountModel(tokenAliasModel: TestUtils.kexTokenAliasModel, defaultDenominationAmount: Decimal.fromInt(10000)),
   );
 
   final IRInboundVerificationRequestModel irInboundVerificationRequestModel3 = IRInboundVerificationRequestModel(
@@ -44,7 +44,7 @@ void main() {
     dateTime: DateTime(2022, 1, 1),
     requesterIrUserProfileModel: irUserProfileModel1,
     records: <String, String>{'id': '4', 'favourite_color': 'green'},
-    tipTokenAmountModel: TokenAmountModel(tokenAliasModel: TestUtils.kexTokenAliasModel, lowestDenominationAmount: Decimal.fromInt(100)),
+    tipTokenAmountModel: TokenAmountModel(tokenAliasModel: TestUtils.kexTokenAliasModel, defaultDenominationAmount: Decimal.fromInt(100)),
   );
 
   final IRInboundVerificationRequestModel irInboundVerificationRequestModel4 = IRInboundVerificationRequestModel(
@@ -52,7 +52,7 @@ void main() {
     dateTime: DateTime(2023, 1, 1),
     requesterIrUserProfileModel: irUserProfileModel2,
     records: <String, String>{'favourite_color': 'blue'},
-    tipTokenAmountModel: TokenAmountModel(tokenAliasModel: TestUtils.kexTokenAliasModel, lowestDenominationAmount: Decimal.fromInt(400)),
+    tipTokenAmountModel: TokenAmountModel(tokenAliasModel: TestUtils.kexTokenAliasModel, defaultDenominationAmount: Decimal.fromInt(400)),
   );
 
   final List<IRInboundVerificationRequestModel> irInboundVerificationRequestModelList = <IRInboundVerificationRequestModel>[

--- a/test/unit/shared/controllers/menu/my_acount_page/verification_requests_page/verification_requests_sort_options_test.dart
+++ b/test/unit/shared/controllers/menu/my_acount_page/verification_requests_page/verification_requests_sort_options_test.dart
@@ -27,7 +27,7 @@ void main() {
     dateTime: DateTime(2020, 1, 1),
     requesterIrUserProfileModel: irUserProfileModel1,
     records: <String, String>{'flower': 'rose'},
-    tipTokenAmountModel: TokenAmountModel(tokenAliasModel: TestUtils.kexTokenAliasModel, lowestDenominationAmount: Decimal.fromInt(500)),
+    tipTokenAmountModel: TokenAmountModel(tokenAliasModel: TestUtils.kexTokenAliasModel, defaultDenominationAmount: Decimal.fromInt(500)),
   );
 
   final IRInboundVerificationRequestModel irInboundVerificationRequestModel2 = IRInboundVerificationRequestModel(
@@ -35,7 +35,7 @@ void main() {
     dateTime: DateTime(2021, 1, 1),
     requesterIrUserProfileModel: irUserProfileModel2,
     records: <String, String>{'username': 'miroman123'},
-    tipTokenAmountModel: TokenAmountModel(tokenAliasModel: TestUtils.kexTokenAliasModel, lowestDenominationAmount: Decimal.fromInt(10000)),
+    tipTokenAmountModel: TokenAmountModel(tokenAliasModel: TestUtils.kexTokenAliasModel, defaultDenominationAmount: Decimal.fromInt(10000)),
   );
 
   final IRInboundVerificationRequestModel irInboundVerificationRequestModel3 = IRInboundVerificationRequestModel(
@@ -43,7 +43,7 @@ void main() {
     dateTime: DateTime(2022, 1, 1),
     requesterIrUserProfileModel: irUserProfileModel1,
     records: <String, String>{'id': '4', 'favourite_color': 'green'},
-    tipTokenAmountModel: TokenAmountModel(tokenAliasModel: TestUtils.kexTokenAliasModel, lowestDenominationAmount: Decimal.fromInt(100)),
+    tipTokenAmountModel: TokenAmountModel(tokenAliasModel: TestUtils.kexTokenAliasModel, defaultDenominationAmount: Decimal.fromInt(100)),
   );
 
   final IRInboundVerificationRequestModel irInboundVerificationRequestModel4 = IRInboundVerificationRequestModel(
@@ -51,7 +51,7 @@ void main() {
     dateTime: DateTime(2023, 1, 1),
     requesterIrUserProfileModel: irUserProfileModel2,
     records: <String, String>{'favourite_color': 'blue'},
-    tipTokenAmountModel: TokenAmountModel(tokenAliasModel: TestUtils.kexTokenAliasModel, lowestDenominationAmount: Decimal.fromInt(400)),
+    tipTokenAmountModel: TokenAmountModel(tokenAliasModel: TestUtils.kexTokenAliasModel, defaultDenominationAmount: Decimal.fromInt(400)),
   );
 
   final List<IRInboundVerificationRequestModel> irInboundVerificationRequestModelList = <IRInboundVerificationRequestModel>[

--- a/test/unit/shared/models/staking/undelegation_model_test.dart
+++ b/test/unit/shared/models/staking/undelegation_model_test.dart
@@ -17,7 +17,7 @@ void main() {
 
   List<TokenAmountModel> actualTokenAmountModelList = <TokenAmountModel>[
     TokenAmountModel(
-      lowestDenominationAmount: Decimal.parse('123'),
+      defaultDenominationAmount: Decimal.parse('123'),
       tokenAliasModel: TokenAliasModel.local('ukex'),
     ),
   ];

--- a/test/unit/shared/models/tokens/prefixed_token_amount_model_test.dart
+++ b/test/unit/shared/models/tokens/prefixed_token_amount_model_test.dart
@@ -9,12 +9,12 @@ import 'package:miro/test/utils/test_utils.dart';
 // fvm flutter test test/unit/shared/models/tokens/prefixed_token_amount_model_test.dart --platform chrome --null-assertions
 void main() {
   TokenAmountModel actualTokenAmountModel = TokenAmountModel(
-    lowestDenominationAmount: Decimal.fromInt(1000),
+    defaultDenominationAmount: Decimal.fromInt(1000),
     tokenAliasModel: TestUtils.kexTokenAliasModel,
   );
 
   group('Tests of PrefixedTokenAmountModel.getAmountAsString()', () {
-    test('Should return [amount in lowest denomination] with ["+" prefix]', () {
+    test('Should return [amount in default denomination] with ["+" prefix]', () {
       // Arrange
       PrefixedTokenAmountModel prefixedTokenAmountModel = PrefixedTokenAmountModel(
         tokenAmountModel: actualTokenAmountModel,
@@ -30,7 +30,7 @@ void main() {
       expect(actualAmountAsString, expectedAmountAsString);
     });
 
-    test('Should return [amount in lowest denomination] with ["-" prefix]', () {
+    test('Should return [amount in default denomination] with ["-" prefix]', () {
       // Arrange
       PrefixedTokenAmountModel prefixedTokenAmountModel = PrefixedTokenAmountModel(
         tokenAmountModel: actualTokenAmountModel,

--- a/test/unit/shared/models/tokens/token_amount_model_test.dart
+++ b/test/unit/shared/models/tokens/token_amount_model_test.dart
@@ -12,39 +12,28 @@ void main() {
   group('Tests of TokenAmountModel', () {
     // Arrange
     TokenAmountModel actualTokenAmountModel = TokenAmountModel(
-      lowestDenominationAmount: Decimal.fromInt(500),
+      defaultDenominationAmount: Decimal.fromInt(500),
       tokenAliasModel: TestUtils.ethTokenAliasModel,
     );
-
-    test('Should return amount in lowest denomination', () {
-      // Act
-      String actualLowestDenominationAmount = actualTokenAmountModel.getAmountInLowestDenomination().toString();
-
-      // Assert
-      String expectedLowestDenominationAmount = '500';
-
-      expect(actualLowestDenominationAmount, expectedLowestDenominationAmount);
-    });
 
     test('Should return amount in default denomination', () {
       // Act
       String actualDefaultDenominationAmount = actualTokenAmountModel.getAmountInDefaultDenomination().toString();
 
       // Assert
-      String expectedDefaultDenominationAmount = '0.0000000000000005';
+      String expectedDefaultDenominationAmount = '500';
 
       expect(actualDefaultDenominationAmount, expectedDefaultDenominationAmount);
     });
 
-    test('Should return amount in selected (lowest) denomination', () {
+    test('Should return amount in network denomination', () {
       // Act
-      TokenDenominationModel lowestTokenDenominationModel = actualTokenAmountModel.tokenAliasModel.lowestTokenDenominationModel;
-      String actualLowestDenominationAmount = actualTokenAmountModel.getAmountInDenomination(lowestTokenDenominationModel).toString();
+      String actualNetworkDenominationAmount = actualTokenAmountModel.getAmountInNetworkDenomination().toString();
 
       // Assert
-      String expectedLowestDenominationAmount = '500';
+      String expectedNetworkDenominationAmount = '0.0000000000000005';
 
-      expect(actualLowestDenominationAmount, expectedLowestDenominationAmount);
+      expect(actualNetworkDenominationAmount, expectedNetworkDenominationAmount);
     });
 
     test('Should return amount in selected (default) denomination', () {
@@ -53,9 +42,20 @@ void main() {
       String actualDefaultDenominationAmount = actualTokenAmountModel.getAmountInDenomination(defaultTokenDenominationModel).toString();
 
       // Assert
-      String expectedDefaultDenominationAmount = '0.0000000000000005';
+      String expectedDefaultDenominationAmount = '500';
 
       expect(actualDefaultDenominationAmount, expectedDefaultDenominationAmount);
+    });
+
+    test('Should return amount in selected (network) denomination', () {
+      // Act
+      TokenDenominationModel networkTokenDenominationModel = actualTokenAmountModel.tokenAliasModel.networkTokenDenominationModel;
+      String actualNetworkDenominationAmount = actualTokenAmountModel.getAmountInDenomination(networkTokenDenominationModel).toString();
+
+      // Assert
+      String expectedNetworkDenominationAmount = '0.0000000000000005';
+
+      expect(actualNetworkDenominationAmount, expectedNetworkDenominationAmount);
     });
   });
 
@@ -66,7 +66,7 @@ void main() {
 
       // Assert
       TokenAmountModel expectedTokenAmountModel = TokenAmountModel(
-        lowestDenominationAmount: Decimal.fromInt(500),
+        defaultDenominationAmount: Decimal.fromInt(500),
         tokenAliasModel: TokenAliasModel.local('ukex'),
       );
 
@@ -79,7 +79,7 @@ void main() {
 
       // Assert
       TokenAmountModel expectedTokenAmountModel = TokenAmountModel(
-        lowestDenominationAmount: Decimal.fromInt(500),
+        defaultDenominationAmount: Decimal.fromInt(500),
         tokenAliasModel: TokenAliasModel.local('v1/ukex'),
       );
 
@@ -90,21 +90,11 @@ void main() {
   group('Tests of TokenAmountModel containing TokenAliasModel created from local() constructor', () {
     // Arrange
     TokenAmountModel actualTokenAmountModel = TokenAmountModel(
-      lowestDenominationAmount: Decimal.fromInt(500),
+      defaultDenominationAmount: Decimal.fromInt(500),
       tokenAliasModel: TokenAliasModel.local('samolean'),
     );
 
-    test('Should return amount in lowest denomination', () {
-      // Act
-      String actualLowestDenominationAmount = actualTokenAmountModel.getAmountInLowestDenomination().toString();
-
-      // Assert
-      String expectedLowestDenominationAmount = '500';
-
-      expect(actualLowestDenominationAmount, expectedLowestDenominationAmount);
-    });
-
-    test('Should return amount in default denomination (in this case lowest denomination should be equal default)', () {
+    test('Should return amount in default denomination', () {
       // Act
       String actualDefaultDenominationAmount = actualTokenAmountModel.getAmountInDefaultDenomination().toString();
 
@@ -114,18 +104,17 @@ void main() {
       expect(actualDefaultDenominationAmount, expectedDefaultDenominationAmount);
     });
 
-    test('Should return amount in selected (lowest) denomination', () {
+    test('Should return amount in network denomination (in this case default denomination should be equal network)', () {
       // Act
-      TokenDenominationModel lowestTokenDenominationModel = actualTokenAmountModel.tokenAliasModel.lowestTokenDenominationModel;
-      String actualLowestDenominationAmount = actualTokenAmountModel.getAmountInDenomination(lowestTokenDenominationModel).toString();
+      String actualNetworkDenominationAmount = actualTokenAmountModel.getAmountInNetworkDenomination().toString();
 
       // Assert
-      String expectedLowestDenominationAmount = '500';
+      String expectedNetworkDenominationAmount = '500';
 
-      expect(actualLowestDenominationAmount, expectedLowestDenominationAmount);
+      expect(actualNetworkDenominationAmount, expectedNetworkDenominationAmount);
     });
 
-    test('Should return amount in selected (default) denomination (in this case lowest denomination should be equal default)', () {
+    test('Should return amount in selected (default) denomination', () {
       // Act
       TokenDenominationModel defaultTokenDenominationModel = actualTokenAmountModel.tokenAliasModel.defaultTokenDenominationModel;
       String actualDefaultDenominationAmount = actualTokenAmountModel.getAmountInDenomination(defaultTokenDenominationModel).toString();
@@ -134,45 +123,45 @@ void main() {
       String expectedDefaultDenominationAmount = '500';
 
       expect(actualDefaultDenominationAmount, expectedDefaultDenominationAmount);
+    });
+
+    test('Should return amount in selected (network) denomination (in this case default denomination should be equal network)', () {
+      // Act
+      TokenDenominationModel networkTokenDenominationModel = actualTokenAmountModel.tokenAliasModel.networkTokenDenominationModel;
+      String actualNetworkDenominationAmount = actualTokenAmountModel.getAmountInDenomination(networkTokenDenominationModel).toString();
+
+      // Assert
+      String expectedNetworkDenominationAmount = '500';
+
+      expect(actualNetworkDenominationAmount, expectedNetworkDenominationAmount);
     });
   });
 
   group('Tests of TokenAmountModel containing TokenAliasModel created from fromDto() constructor', () {
     // Arrange
     TokenAmountModel actualTokenAmountModel = TokenAmountModel(
-      lowestDenominationAmount: Decimal.fromInt(500),
+      defaultDenominationAmount: Decimal.fromInt(500),
       tokenAliasModel: TestUtils.kexTokenAliasModel,
     );
-
-    test('Should return amount in lowest denomination', () {
-      // Act
-      String actualLowestDenominationAmount = actualTokenAmountModel.getAmountInLowestDenomination().toString();
-
-      // Assert
-      String expectedLowestDenominationAmount = '500';
-
-      expect(actualLowestDenominationAmount, expectedLowestDenominationAmount);
-    });
 
     test('Should return amount in default denomination', () {
       // Act
       String actualDefaultDenominationAmount = actualTokenAmountModel.getAmountInDefaultDenomination().toString();
 
       // Assert
-      String expectedLowestDenominationAmount = '0.0005';
+      String expectedDefaultDenominationAmount = '500';
 
-      expect(actualDefaultDenominationAmount, expectedLowestDenominationAmount);
+      expect(actualDefaultDenominationAmount, expectedDefaultDenominationAmount);
     });
 
-    test('Should return amount in selected (lowest) denomination', () {
+    test('Should return amount in network denomination', () {
       // Act
-      TokenDenominationModel lowestTokenDenominationModel = actualTokenAmountModel.tokenAliasModel.lowestTokenDenominationModel;
-      String actualLowestDenominationAmount = actualTokenAmountModel.getAmountInDenomination(lowestTokenDenominationModel).toString();
+      String actualNetworkDenominationAmount = actualTokenAmountModel.getAmountInNetworkDenomination().toString();
 
       // Assert
-      String expectedLowestDenominationAmount = '500';
+      String expectedNetworkDenominationAmount = '0.0005';
 
-      expect(actualLowestDenominationAmount, expectedLowestDenominationAmount);
+      expect(actualNetworkDenominationAmount, expectedNetworkDenominationAmount);
     });
 
     test('Should return amount in selected (default) denomination', () {
@@ -181,106 +170,52 @@ void main() {
       String actualDefaultDenominationAmount = actualTokenAmountModel.getAmountInDenomination(defaultTokenDenominationModel).toString();
 
       // Assert
-      String expectedDefaultDenominationAmount = '0.0005';
+      String expectedDefaultDenominationAmount = '500';
 
       expect(actualDefaultDenominationAmount, expectedDefaultDenominationAmount);
+    });
+
+    test('Should return amount in selected (network) denomination', () {
+      // Act
+      TokenDenominationModel networkTokenDenominationModel = actualTokenAmountModel.tokenAliasModel.networkTokenDenominationModel;
+      String actualNetworkDenominationAmount = actualTokenAmountModel.getAmountInDenomination(networkTokenDenominationModel).toString();
+
+      // Assert
+      String expectedNetworkDenominationAmount = '0.0005';
+
+      expect(actualNetworkDenominationAmount, expectedNetworkDenominationAmount);
     });
   });
 
   group('Tests of TokenAmountModel working with very small values', () {
     // Arrange
     TokenAmountModel actualTokenAmountModel = TokenAmountModel(
-      lowestDenominationAmount: Decimal.fromInt(4),
+      defaultDenominationAmount: Decimal.fromInt(4),
       tokenAliasModel: const TokenAliasModel(
         name: 'test',
-        lowestTokenDenominationModel: TokenDenominationModel(name: 'min', decimals: 0),
-        defaultTokenDenominationModel: TokenDenominationModel(name: 'max', decimals: 50),
+        defaultTokenDenominationModel: TokenDenominationModel(name: 'min', decimals: 0),
+        networkTokenDenominationModel: TokenDenominationModel(name: 'max', decimals: 50),
       ),
     );
-
-    test('Should return amount in lowest denomination', () {
-      // Act
-      String actualLowestDenominationAmount = actualTokenAmountModel.getAmountInLowestDenomination().toString();
-
-      // Assert
-      String expectedLowestDenominationAmount = '4';
-
-      expect(actualLowestDenominationAmount, expectedLowestDenominationAmount);
-    });
 
     test('Should return amount in default denomination', () {
       // Act
       String actualDefaultDenominationAmount = actualTokenAmountModel.getAmountInDefaultDenomination().toString();
 
       // Assert
-      String expectedLowestDenominationAmount = '0.00000000000000000000000000000000000000000000000004';
-
-      expect(actualDefaultDenominationAmount, expectedLowestDenominationAmount);
-    });
-
-    test('Should return amount in selected (lowest) denomination', () {
-      // Act
-      TokenDenominationModel lowestTokenDenominationModel = actualTokenAmountModel.tokenAliasModel.lowestTokenDenominationModel;
-      String actualLowestDenominationAmount = actualTokenAmountModel.getAmountInDenomination(lowestTokenDenominationModel).toString();
-
-      // Assert
-      String expectedLowestDenominationAmount = '4';
-
-      expect(actualLowestDenominationAmount, expectedLowestDenominationAmount);
-    });
-
-    test('Should return amount in selected (default) denomination', () {
-      // Act
-      TokenDenominationModel defaultTokenDenominationModel = actualTokenAmountModel.tokenAliasModel.defaultTokenDenominationModel;
-      String actualDefaultDenominationAmount = actualTokenAmountModel.getAmountInDenomination(defaultTokenDenominationModel).toString();
-
-      // Assert
-      String expectedDefaultDenominationAmount = '0.00000000000000000000000000000000000000000000000004';
+      String expectedDefaultDenominationAmount = '4';
 
       expect(actualDefaultDenominationAmount, expectedDefaultDenominationAmount);
     });
-  });
 
-  group('Tests of TokenAmountModel working with very big values', () {
-    // Arrange
-    TokenAmountModel actualTokenAmountModel = TokenAmountModel(
-      lowestDenominationAmount: Decimal.parse('400000000000000000000000000000000000000000000000000'),
-      tokenAliasModel: const TokenAliasModel(
-        name: 'test',
-        lowestTokenDenominationModel: TokenDenominationModel(name: 'min', decimals: 0),
-        defaultTokenDenominationModel: TokenDenominationModel(name: 'max', decimals: 50),
-      ),
-    );
-
-    test('Should return amount in lowest denomination', () {
+    test('Should return amount in network denomination', () {
       // Act
-      String actualLowestDenominationAmount = actualTokenAmountModel.getAmountInLowestDenomination().toString();
+      String actualNetworkDenominationAmount = actualTokenAmountModel.getAmountInNetworkDenomination().toString();
 
       // Assert
-      String expectedLowestDenominationAmount = '400000000000000000000000000000000000000000000000000';
+      String expectedNetworkDenominationAmount = '0.00000000000000000000000000000000000000000000000004';
 
-      expect(actualLowestDenominationAmount, expectedLowestDenominationAmount);
-    });
-
-    test('Should return amount in default denomination', () {
-      // Act
-      String actualDefaultDenominationAmount = actualTokenAmountModel.getAmountInDefaultDenomination().toString();
-
-      // Assert
-      String expectedLowestDenominationAmount = '4';
-
-      expect(actualDefaultDenominationAmount, expectedLowestDenominationAmount);
-    });
-
-    test('Should return amount in selected (lowest) denomination', () {
-      // Act
-      TokenDenominationModel lowestTokenDenominationModel = actualTokenAmountModel.tokenAliasModel.lowestTokenDenominationModel;
-      String actualLowestDenominationAmount = actualTokenAmountModel.getAmountInDenomination(lowestTokenDenominationModel).toString();
-
-      // Assert
-      String expectedLowestDenominationAmount = '400000000000000000000000000000000000000000000000000';
-
-      expect(actualLowestDenominationAmount, expectedLowestDenominationAmount);
+      expect(actualNetworkDenominationAmount, expectedNetworkDenominationAmount);
     });
 
     test('Should return amount in selected (default) denomination', () {
@@ -293,63 +228,128 @@ void main() {
 
       expect(actualDefaultDenominationAmount, expectedDefaultDenominationAmount);
     });
+
+    test('Should return amount in selected (network) denomination', () {
+      // Act
+      TokenDenominationModel networkTokenDenominationModel = actualTokenAmountModel.tokenAliasModel.networkTokenDenominationModel;
+      String actualNetworkDenominationAmount = actualTokenAmountModel.getAmountInDenomination(networkTokenDenominationModel).toString();
+
+      // Assert
+      String expectedNetworkDenominationAmount = '0.00000000000000000000000000000000000000000000000004';
+
+      expect(actualNetworkDenominationAmount, expectedNetworkDenominationAmount);
+    });
+  });
+
+  group('Tests of TokenAmountModel working with very big values', () {
+    // Arrange
+    TokenAmountModel actualTokenAmountModel = TokenAmountModel(
+      defaultDenominationAmount: Decimal.parse('400000000000000000000000000000000000000000000000000'),
+      tokenAliasModel: const TokenAliasModel(
+        name: 'test',
+        defaultTokenDenominationModel: TokenDenominationModel(name: 'min', decimals: 0),
+        networkTokenDenominationModel: TokenDenominationModel(name: 'max', decimals: 50),
+      ),
+    );
+
+    test('Should return amount in default denomination', () {
+      // Act
+      String actualDefaultDenominationAmount = actualTokenAmountModel.getAmountInDefaultDenomination().toString();
+
+      // Assert
+      String expectedDefaultDenominationAmount = '400000000000000000000000000000000000000000000000000';
+
+      expect(actualDefaultDenominationAmount, expectedDefaultDenominationAmount);
+    });
+
+    test('Should return amount in network denomination', () {
+      // Act
+      String actualNetworkDenominationAmount = actualTokenAmountModel.getAmountInNetworkDenomination().toString();
+
+      // Assert
+      String expectedNetworkDenominationAmount = '4';
+
+      expect(actualNetworkDenominationAmount, expectedNetworkDenominationAmount);
+    });
+
+    test('Should return amount in selected (default) denomination', () {
+      // Act
+      TokenDenominationModel defaultTokenDenominationModel = actualTokenAmountModel.tokenAliasModel.defaultTokenDenominationModel;
+      String actualDefaultDenominationAmount = actualTokenAmountModel.getAmountInDenomination(defaultTokenDenominationModel).toString();
+
+      // Assert
+      String expectedDefaultDenominationAmount = '400000000000000000000000000000000000000000000000000';
+
+      expect(actualDefaultDenominationAmount, expectedDefaultDenominationAmount);
+    });
+
+    test('Should return amount in selected (network) denomination', () {
+      // Act
+      TokenDenominationModel networkTokenDenominationModel = actualTokenAmountModel.tokenAliasModel.networkTokenDenominationModel;
+      String actualNetworkDenominationAmount = actualTokenAmountModel.getAmountInDenomination(networkTokenDenominationModel).toString();
+
+      // Assert
+      String expectedNetworkDenominationAmount = '4';
+
+      expect(actualNetworkDenominationAmount, expectedNetworkDenominationAmount);
+    });
   });
 
   group('Tests of TokenAmountModel.setAmount() method', () {
     // Arrange
     TokenAmountModel actualTokenAmountModel = TokenAmountModel(
-      lowestDenominationAmount: Decimal.fromInt(500),
+      defaultDenominationAmount: Decimal.fromInt(500),
       tokenAliasModel: TestUtils.ethTokenAliasModel,
     );
 
     test('Should update actualTokenAmount to 1000', () {
       // Act
       actualTokenAmountModel.setAmount(Decimal.fromInt(1000));
-      String actualLowestTokenAmount = actualTokenAmountModel.getAmountInLowestDenomination().toString();
+      String actualDefaultTokenAmount = actualTokenAmountModel.getAmountInDefaultDenomination().toString();
 
       // Assert
-      String expectedLowestTokenAmount = '1000';
+      String expectedDefaultTokenAmount = '1000';
 
-      expect(actualLowestTokenAmount, expectedLowestTokenAmount);
+      expect(actualDefaultTokenAmount, expectedDefaultTokenAmount);
     });
 
     test('Should update actualTokenAmount to 100000000000000000000000', () {
       // Act
       actualTokenAmountModel.setAmount(Decimal.parse('100000000000000000000000'));
-      String actualLowestTokenAmount = actualTokenAmountModel.getAmountInLowestDenomination().toString();
+      String actualDefaultTokenAmount = actualTokenAmountModel.getAmountInDefaultDenomination().toString();
 
       // Assert
-      String expectedLowestTokenAmount = '100000000000000000000000';
+      String expectedDefaultTokenAmount = '100000000000000000000000';
 
-      expect(actualLowestTokenAmount, expectedLowestTokenAmount);
+      expect(actualDefaultTokenAmount, expectedDefaultTokenAmount);
     });
 
-    test('Should calculate "1000" to lowest denomination and set it as actual amount', () {
+    test('Should calculate "1000" to default denomination and set it as actual amount', () {
       // Arrange
-      TokenDenominationModel defaultTokenDenominationModel = actualTokenAmountModel.tokenAliasModel.defaultTokenDenominationModel;
+      TokenDenominationModel defaultTokenDenominationModel = actualTokenAmountModel.tokenAliasModel.networkTokenDenominationModel;
 
       // Act
       actualTokenAmountModel.setAmount(Decimal.parse('1000'), tokenDenominationModel: defaultTokenDenominationModel);
-      String actualLowestTokenAmount = actualTokenAmountModel.getAmountInLowestDenomination().toString();
+      String actualDefaultTokenAmount = actualTokenAmountModel.getAmountInDefaultDenomination().toString();
 
       // Assert
-      String expectedLowestTokenAmount = '1000000000000000000000';
+      String expectedDefaultTokenAmount = '1000000000000000000000';
 
-      expect(actualLowestTokenAmount, expectedLowestTokenAmount);
+      expect(actualDefaultTokenAmount, expectedDefaultTokenAmount);
     });
 
-    test('Should calculate "2" to lowest denomination and set it as actual amount', () {
+    test('Should calculate "2" to default denomination and set it as actual amount', () {
       // Arrange
-      TokenDenominationModel defaultTokenDenominationModel = actualTokenAmountModel.tokenAliasModel.defaultTokenDenominationModel;
+      TokenDenominationModel defaultTokenDenominationModel = actualTokenAmountModel.tokenAliasModel.networkTokenDenominationModel;
 
       // Act
       actualTokenAmountModel.setAmount(Decimal.parse('2'), tokenDenominationModel: defaultTokenDenominationModel);
-      String actualLowestTokenAmount = actualTokenAmountModel.getAmountInLowestDenomination().toString();
+      String actualDefaultTokenAmount = actualTokenAmountModel.getAmountInDefaultDenomination().toString();
 
       // Assert
-      String expectedLowestTokenAmount = '2000000000000000000';
+      String expectedDefaultTokenAmount = '2000000000000000000';
 
-      expect(actualLowestTokenAmount, expectedLowestTokenAmount);
+      expect(actualDefaultTokenAmount, expectedDefaultTokenAmount);
     });
   });
 
@@ -357,11 +357,11 @@ void main() {
     test('Should [add] TokenAmountModels if [aliases EQUAL] ', () {
       // Arrange
       TokenAmountModel actualFirstTokenAmountModel = TokenAmountModel(
-        lowestDenominationAmount: Decimal.fromInt(500),
+        defaultDenominationAmount: Decimal.fromInt(500),
         tokenAliasModel: TestUtils.ethTokenAliasModel,
       );
       TokenAmountModel actualSecondTokenAmountModel = TokenAmountModel(
-        lowestDenominationAmount: Decimal.fromInt(600),
+        defaultDenominationAmount: Decimal.fromInt(600),
         tokenAliasModel: TestUtils.ethTokenAliasModel,
       );
 
@@ -370,7 +370,7 @@ void main() {
 
       // Assert
       TokenAmountModel expectedResultTokenAmountModel = TokenAmountModel(
-        lowestDenominationAmount: Decimal.fromInt(1100),
+        defaultDenominationAmount: Decimal.fromInt(1100),
         tokenAliasModel: TestUtils.ethTokenAliasModel,
       );
 
@@ -380,11 +380,11 @@ void main() {
     test('Should [ignore adding] TokenAmountModels if [aliases DIFFERENT] ', () {
       // Arrange
       TokenAmountModel actualFirstTokenAmountModel = TokenAmountModel(
-        lowestDenominationAmount: Decimal.fromInt(500),
+        defaultDenominationAmount: Decimal.fromInt(500),
         tokenAliasModel: TestUtils.ethTokenAliasModel,
       );
       TokenAmountModel actualSecondTokenAmountModel = TokenAmountModel(
-        lowestDenominationAmount: Decimal.fromInt(600),
+        defaultDenominationAmount: Decimal.fromInt(600),
         tokenAliasModel: TestUtils.kexTokenAliasModel,
       );
 
@@ -393,7 +393,7 @@ void main() {
 
       // Assert
       TokenAmountModel expectedResultTokenAmountModel = TokenAmountModel(
-        lowestDenominationAmount: Decimal.fromInt(500),
+        defaultDenominationAmount: Decimal.fromInt(500),
         tokenAliasModel: TestUtils.ethTokenAliasModel,
       );
 
@@ -405,11 +405,11 @@ void main() {
     test('Should [subtract] TokenAmountModels if [aliases EQUAL] ', () {
       // Arrange
       TokenAmountModel actualFirstTokenAmountModel = TokenAmountModel(
-        lowestDenominationAmount: Decimal.fromInt(500),
+        defaultDenominationAmount: Decimal.fromInt(500),
         tokenAliasModel: TestUtils.ethTokenAliasModel,
       );
       TokenAmountModel actualSecondTokenAmountModel = TokenAmountModel(
-        lowestDenominationAmount: Decimal.fromInt(400),
+        defaultDenominationAmount: Decimal.fromInt(400),
         tokenAliasModel: TestUtils.ethTokenAliasModel,
       );
 
@@ -418,7 +418,7 @@ void main() {
 
       // Assert
       TokenAmountModel expectedResultTokenAmountModel = TokenAmountModel(
-        lowestDenominationAmount: Decimal.fromInt(100),
+        defaultDenominationAmount: Decimal.fromInt(100),
         tokenAliasModel: TestUtils.ethTokenAliasModel,
       );
 
@@ -428,11 +428,11 @@ void main() {
     test('Should [ignore subtracting] TokenAmountModels if [aliases DIFFERENT] ', () {
       // Arrange
       TokenAmountModel actualFirstTokenAmountModel = TokenAmountModel(
-        lowestDenominationAmount: Decimal.fromInt(500),
+        defaultDenominationAmount: Decimal.fromInt(500),
         tokenAliasModel: TestUtils.ethTokenAliasModel,
       );
       TokenAmountModel actualSecondTokenAmountModel = TokenAmountModel(
-        lowestDenominationAmount: Decimal.fromInt(600),
+        defaultDenominationAmount: Decimal.fromInt(600),
         tokenAliasModel: TestUtils.kexTokenAliasModel,
       );
 
@@ -441,7 +441,7 @@ void main() {
 
       // Assert
       TokenAmountModel expectedResultTokenAmountModel = TokenAmountModel(
-        lowestDenominationAmount: Decimal.fromInt(500),
+        defaultDenominationAmount: Decimal.fromInt(500),
         tokenAliasModel: TestUtils.ethTokenAliasModel,
       );
 
@@ -451,11 +451,11 @@ void main() {
     test('Should [return 0] if result of subtraction is negative ', () {
       // Arrange
       TokenAmountModel actualFirstTokenAmountModel = TokenAmountModel(
-        lowestDenominationAmount: Decimal.fromInt(500),
+        defaultDenominationAmount: Decimal.fromInt(500),
         tokenAliasModel: TestUtils.ethTokenAliasModel,
       );
       TokenAmountModel actualSecondTokenAmountModel = TokenAmountModel(
-        lowestDenominationAmount: Decimal.fromInt(600),
+        defaultDenominationAmount: Decimal.fromInt(600),
         tokenAliasModel: TestUtils.ethTokenAliasModel,
       );
 
@@ -464,7 +464,7 @@ void main() {
 
       // Assert
       TokenAmountModel expectedResultTokenAmountModel = TokenAmountModel(
-        lowestDenominationAmount: Decimal.fromInt(0),
+        defaultDenominationAmount: Decimal.fromInt(0),
         tokenAliasModel: TestUtils.ethTokenAliasModel,
       );
 
@@ -476,7 +476,7 @@ void main() {
     test('Should throw ArgumentError for setAmount() method if amount is less than zero', () {
       // Arrange
       TokenAmountModel actualTokenAmountModel = TokenAmountModel(
-        lowestDenominationAmount: Decimal.fromInt(500),
+        defaultDenominationAmount: Decimal.fromInt(500),
         tokenAliasModel: TestUtils.ethTokenAliasModel,
       );
 
@@ -490,14 +490,14 @@ void main() {
     test('Should set -1 as amount if TokenAmountModel constructor has amount less than zero', () {
       // Act
       TokenAmountModel actualTokenAmountModel = TokenAmountModel(
-        lowestDenominationAmount: Decimal.fromInt(-5000),
+        defaultDenominationAmount: Decimal.fromInt(-5000),
         tokenAliasModel: TestUtils.ethTokenAliasModel,
       );
-      String actualLowestDenominationAmount = actualTokenAmountModel.getAmountInLowestDenomination().toString();
+      String actualDefaultDenominationAmount = actualTokenAmountModel.getAmountInDefaultDenomination().toString();
 
       // Assert
-      String expectedLowestDenominationAmount = '-1';
-      expect(actualLowestDenominationAmount, expectedLowestDenominationAmount);
+      String expectedDefaultDenominationAmount = '-1';
+      expect(actualDefaultDenominationAmount, expectedDefaultDenominationAmount);
     });
   });
 }

--- a/test/unit/shared/models/transactions/form_models/ir_msg_handle_verification_request_form_model_test.dart
+++ b/test/unit/shared/models/transactions/form_models/ir_msg_handle_verification_request_form_model_test.dart
@@ -13,7 +13,7 @@ void main() {
   WalletAddress actualSenderAddress = WalletAddress.fromBech32('kira143q8vxpvuykt9pq50e6hng9s38vmy844n8k9wx');
   IRInboundVerificationRequestModel actualIrVerificationRequestModel = IRInboundVerificationRequestModel(
     id: '3',
-    tipTokenAmountModel: TokenAmountModel(lowestDenominationAmount: Decimal.fromInt(200), tokenAliasModel: TokenAliasModel.local('ukex')),
+    tipTokenAmountModel: TokenAmountModel(defaultDenominationAmount: Decimal.fromInt(200), tokenAliasModel: TokenAliasModel.local('ukex')),
     dateTime: DateTime.parse('2021-09-30 12:00:00'),
     requesterIrUserProfileModel: IRUserProfileModel(
       walletAddress: WalletAddress.fromBech32('kira143q8vxpvuykt9pq50e6hng9s38vmy844n8k9wx'),

--- a/test/unit/shared/models/transactions/form_models/ir_msg_request_verification_form_model_test.dart
+++ b/test/unit/shared/models/transactions/form_models/ir_msg_request_verification_form_model_test.dart
@@ -12,7 +12,7 @@ void main() {
   WalletAddress actualRequesterWalletAddress = WalletAddress.fromBech32('kira143q8vxpvuykt9pq50e6hng9s38vmy844n8k9wx');
   WalletAddress actualVerifierWalletAddress = WalletAddress.fromBech32('kira177lwmjyjds3cy7trers83r4pjn3dhv8zrqk9dl');
   TokenAmountModel actualTipTokenAmountModel = TokenAmountModel(
-    lowestDenominationAmount: Decimal.fromInt(100),
+    defaultDenominationAmount: Decimal.fromInt(100),
     tokenAliasModel: TokenAliasModel.local('ukex'),
   );
 
@@ -48,7 +48,7 @@ void main() {
       IRMsgRequestVerificationFormModel actualIrMsgRequestVerificationFormModel = IRMsgRequestVerificationFormModel(
         irRecordModel: actualIrRecordModel,
         tipTokenAmountModel: TokenAmountModel(
-          lowestDenominationAmount: Decimal.fromInt(0),
+          defaultDenominationAmount: Decimal.fromInt(0),
           tokenAliasModel: TokenAliasModel.local('ukex'),
         ),
         requesterWalletAddress: actualRequesterWalletAddress,
@@ -140,7 +140,7 @@ void main() {
       IRMsgRequestVerificationFormModel actualIrMsgRequestVerificationFormModel = IRMsgRequestVerificationFormModel(
         irRecordModel: actualIrRecordModel,
         tipTokenAmountModel: TokenAmountModel(
-          lowestDenominationAmount: Decimal.fromInt(0),
+          defaultDenominationAmount: Decimal.fromInt(0),
           tokenAliasModel: TokenAliasModel.local('ukex'),
         ),
         requesterWalletAddress: actualRequesterWalletAddress,

--- a/test/unit/shared/models/transactions/form_models/msg_send_form_model_test.dart
+++ b/test/unit/shared/models/transactions/form_models/msg_send_form_model_test.dart
@@ -11,7 +11,7 @@ void main() {
   WalletAddress actualSenderAddress = WalletAddress.fromBech32('kira143q8vxpvuykt9pq50e6hng9s38vmy844n8k9wx');
   WalletAddress actualRecipientAddress = WalletAddress.fromBech32('kira177lwmjyjds3cy7trers83r4pjn3dhv8zrqk9dl');
   TokenAmountModel actualTokenAmountModel = TokenAmountModel(
-    lowestDenominationAmount: Decimal.fromInt(100),
+    defaultDenominationAmount: Decimal.fromInt(100),
     tokenAliasModel: TokenAliasModel.local('ukex'),
   );
 
@@ -37,7 +37,7 @@ void main() {
         senderWalletAddress: actualSenderAddress,
         recipientWalletAddress: actualRecipientAddress,
         tokenAmountModel: TokenAmountModel(
-          lowestDenominationAmount: Decimal.fromInt(0),
+          defaultDenominationAmount: Decimal.fromInt(0),
           tokenAliasModel: TokenAliasModel.local('ukex'),
         ),
       );
@@ -123,7 +123,7 @@ void main() {
         senderWalletAddress: actualSenderAddress,
         recipientWalletAddress: actualRecipientAddress,
         tokenAmountModel: TokenAmountModel(
-          lowestDenominationAmount: Decimal.fromInt(0),
+          defaultDenominationAmount: Decimal.fromInt(0),
           tokenAliasModel: TokenAliasModel.local('ukex'),
         ),
       );

--- a/test/unit/shared/models/transactions/form_models/staking_msg_delegate_form_model_test.dart
+++ b/test/unit/shared/models/transactions/form_models/staking_msg_delegate_form_model_test.dart
@@ -12,7 +12,7 @@ void main() {
   WalletAddress actualValoperWalletAddress = WalletAddress.fromBech32('kiravaloper1c6slygj2tx7hzm0mn4qeflqpvngj73c2cw7fh7');
   List<TokenAmountModel> actualTokenAmountModels = <TokenAmountModel>[
     TokenAmountModel(
-      lowestDenominationAmount: Decimal.fromInt(100),
+      defaultDenominationAmount: Decimal.fromInt(100),
       tokenAliasModel: TokenAliasModel.local('ukex'),
     ),
   ];
@@ -46,7 +46,7 @@ void main() {
         valoperWalletAddress: actualValoperWalletAddress,
         tokenAmountModels: <TokenAmountModel>[
           TokenAmountModel(
-            lowestDenominationAmount: Decimal.fromInt(0),
+            defaultDenominationAmount: Decimal.fromInt(0),
             tokenAliasModel: TokenAliasModel.local('ukex'),
           ),
         ],
@@ -128,7 +128,7 @@ void main() {
         valoperWalletAddress: actualValoperWalletAddress,
         tokenAmountModels: <TokenAmountModel>[
           TokenAmountModel(
-            lowestDenominationAmount: Decimal.fromInt(0),
+            defaultDenominationAmount: Decimal.fromInt(0),
             tokenAliasModel: TokenAliasModel.local('ukex'),
           ),
         ],

--- a/test/unit/shared/models/transactions/form_models/staking_msg_undelegate_form_model_test.dart
+++ b/test/unit/shared/models/transactions/form_models/staking_msg_undelegate_form_model_test.dart
@@ -12,7 +12,7 @@ void main() {
   WalletAddress actualValoperWalletAddress = WalletAddress.fromBech32('kiravaloper1c6slygj2tx7hzm0mn4qeflqpvngj73c2cw7fh7');
   List<TokenAmountModel> actualTokenAmountModels = <TokenAmountModel>[
     TokenAmountModel(
-      lowestDenominationAmount: Decimal.fromInt(100),
+      defaultDenominationAmount: Decimal.fromInt(100),
       tokenAliasModel: TokenAliasModel.local('ukex'),
     ),
   ];
@@ -40,7 +40,7 @@ void main() {
         valoperWalletAddress: actualValoperWalletAddress,
         tokenAmountModels: <TokenAmountModel>[
           TokenAmountModel(
-            lowestDenominationAmount: Decimal.fromInt(0),
+            defaultDenominationAmount: Decimal.fromInt(0),
             tokenAliasModel: TokenAliasModel.local('ukex'),
           ),
         ],
@@ -128,7 +128,7 @@ void main() {
         valoperWalletAddress: actualValoperWalletAddress,
         tokenAmountModels: <TokenAmountModel>[
           TokenAmountModel(
-            lowestDenominationAmount: Decimal.fromInt(0),
+            defaultDenominationAmount: Decimal.fromInt(0),
             tokenAliasModel: TokenAliasModel.local('ukex'),
           ),
         ],

--- a/test/unit/shared/models/transactions/tx_list_item_model_test.dart
+++ b/test/unit/shared/models/transactions/tx_list_item_model_test.dart
@@ -24,19 +24,19 @@ void main() {
         txDirectionType: TxDirectionType.outbound,
         txStatusType: TxStatusType.confirmed,
         fees: <TokenAmountModel>[
-          TokenAmountModel(lowestDenominationAmount: Decimal.fromInt(100), tokenAliasModel: TestUtils.kexTokenAliasModel),
+          TokenAmountModel(defaultDenominationAmount: Decimal.fromInt(100), tokenAliasModel: TestUtils.kexTokenAliasModel),
         ],
         prefixedTokenAmounts: <PrefixedTokenAmountModel>[
           PrefixedTokenAmountModel(
             tokenAmountPrefixType: TokenAmountPrefixType.subtract,
-            tokenAmountModel: TokenAmountModel(lowestDenominationAmount: Decimal.fromInt(100), tokenAliasModel: TestUtils.kexTokenAliasModel),
+            tokenAmountModel: TokenAmountModel(defaultDenominationAmount: Decimal.fromInt(100), tokenAliasModel: TestUtils.kexTokenAliasModel),
           ),
         ],
         txMsgModels: <ATxMsgModel>[
           MsgSendModel(
               fromWalletAddress: WalletAddress.fromBech32('kira143q8vxpvuykt9pq50e6hng9s38vmy844n8k9wx'),
               toWalletAddress: WalletAddress.fromBech32('kira177lwmjyjds3cy7trers83r4pjn3dhv8zrqk9dl'),
-              tokenAmountModel: TokenAmountModel(lowestDenominationAmount: Decimal.fromInt(100), tokenAliasModel: TestUtils.kexTokenAliasModel)),
+              tokenAmountModel: TokenAmountModel(defaultDenominationAmount: Decimal.fromInt(100), tokenAliasModel: TestUtils.kexTokenAliasModel)),
         ],
       );
 
@@ -52,19 +52,19 @@ void main() {
         txDirectionType: TxDirectionType.inbound,
         txStatusType: TxStatusType.confirmed,
         fees: <TokenAmountModel>[
-          TokenAmountModel(lowestDenominationAmount: Decimal.fromInt(100), tokenAliasModel: TestUtils.kexTokenAliasModel),
+          TokenAmountModel(defaultDenominationAmount: Decimal.fromInt(100), tokenAliasModel: TestUtils.kexTokenAliasModel),
         ],
         prefixedTokenAmounts: <PrefixedTokenAmountModel>[
           PrefixedTokenAmountModel(
             tokenAmountPrefixType: TokenAmountPrefixType.subtract,
-            tokenAmountModel: TokenAmountModel(lowestDenominationAmount: Decimal.fromInt(100), tokenAliasModel: TestUtils.kexTokenAliasModel),
+            tokenAmountModel: TokenAmountModel(defaultDenominationAmount: Decimal.fromInt(100), tokenAliasModel: TestUtils.kexTokenAliasModel),
           ),
         ],
         txMsgModels: <ATxMsgModel>[
           MsgSendModel(
               fromWalletAddress: WalletAddress.fromBech32('kira143q8vxpvuykt9pq50e6hng9s38vmy844n8k9wx'),
               toWalletAddress: WalletAddress.fromBech32('kira177lwmjyjds3cy7trers83r4pjn3dhv8zrqk9dl'),
-              tokenAmountModel: TokenAmountModel(lowestDenominationAmount: Decimal.fromInt(100), tokenAliasModel: TestUtils.kexTokenAliasModel)),
+              tokenAmountModel: TokenAmountModel(defaultDenominationAmount: Decimal.fromInt(100), tokenAliasModel: TestUtils.kexTokenAliasModel)),
         ],
       );
 
@@ -82,12 +82,12 @@ void main() {
         txDirectionType: TxDirectionType.outbound,
         txStatusType: TxStatusType.confirmed,
         fees: <TokenAmountModel>[
-          TokenAmountModel(lowestDenominationAmount: Decimal.fromInt(100), tokenAliasModel: TestUtils.kexTokenAliasModel),
+          TokenAmountModel(defaultDenominationAmount: Decimal.fromInt(100), tokenAliasModel: TestUtils.kexTokenAliasModel),
         ],
         prefixedTokenAmounts: <PrefixedTokenAmountModel>[
           PrefixedTokenAmountModel(
             tokenAmountPrefixType: TokenAmountPrefixType.subtract,
-            tokenAmountModel: TokenAmountModel(lowestDenominationAmount: Decimal.fromInt(100), tokenAliasModel: TestUtils.kexTokenAliasModel),
+            tokenAmountModel: TokenAmountModel(defaultDenominationAmount: Decimal.fromInt(100), tokenAliasModel: TestUtils.kexTokenAliasModel),
           ),
         ],
         txMsgModels: <ATxMsgModel>[],
@@ -110,19 +110,19 @@ void main() {
         txDirectionType: TxDirectionType.outbound,
         txStatusType: TxStatusType.confirmed,
         fees: <TokenAmountModel>[
-          TokenAmountModel(lowestDenominationAmount: Decimal.fromInt(100), tokenAliasModel: TestUtils.kexTokenAliasModel),
+          TokenAmountModel(defaultDenominationAmount: Decimal.fromInt(100), tokenAliasModel: TestUtils.kexTokenAliasModel),
         ],
         prefixedTokenAmounts: <PrefixedTokenAmountModel>[
           PrefixedTokenAmountModel(
             tokenAmountPrefixType: TokenAmountPrefixType.subtract,
-            tokenAmountModel: TokenAmountModel(lowestDenominationAmount: Decimal.fromInt(100), tokenAliasModel: TestUtils.kexTokenAliasModel),
+            tokenAmountModel: TokenAmountModel(defaultDenominationAmount: Decimal.fromInt(100), tokenAliasModel: TestUtils.kexTokenAliasModel),
           ),
         ],
         txMsgModels: <ATxMsgModel>[
           MsgSendModel(
               fromWalletAddress: WalletAddress.fromBech32('kira143q8vxpvuykt9pq50e6hng9s38vmy844n8k9wx'),
               toWalletAddress: WalletAddress.fromBech32('kira177lwmjyjds3cy7trers83r4pjn3dhv8zrqk9dl'),
-              tokenAmountModel: TokenAmountModel(lowestDenominationAmount: Decimal.fromInt(100), tokenAliasModel: TestUtils.kexTokenAliasModel)),
+              tokenAmountModel: TokenAmountModel(defaultDenominationAmount: Decimal.fromInt(100), tokenAliasModel: TestUtils.kexTokenAliasModel)),
         ],
       );
 
@@ -143,23 +143,23 @@ void main() {
         txDirectionType: TxDirectionType.outbound,
         txStatusType: TxStatusType.confirmed,
         fees: <TokenAmountModel>[
-          TokenAmountModel(lowestDenominationAmount: Decimal.fromInt(100), tokenAliasModel: TestUtils.kexTokenAliasModel),
+          TokenAmountModel(defaultDenominationAmount: Decimal.fromInt(100), tokenAliasModel: TestUtils.kexTokenAliasModel),
         ],
         prefixedTokenAmounts: <PrefixedTokenAmountModel>[
           PrefixedTokenAmountModel(
             tokenAmountPrefixType: TokenAmountPrefixType.subtract,
-            tokenAmountModel: TokenAmountModel(lowestDenominationAmount: Decimal.fromInt(100), tokenAliasModel: TestUtils.kexTokenAliasModel),
+            tokenAmountModel: TokenAmountModel(defaultDenominationAmount: Decimal.fromInt(100), tokenAliasModel: TestUtils.kexTokenAliasModel),
           ),
         ],
         txMsgModels: <ATxMsgModel>[
           MsgSendModel(
               fromWalletAddress: WalletAddress.fromBech32('kira143q8vxpvuykt9pq50e6hng9s38vmy844n8k9wx'),
               toWalletAddress: WalletAddress.fromBech32('kira177lwmjyjds3cy7trers83r4pjn3dhv8zrqk9dl'),
-              tokenAmountModel: TokenAmountModel(lowestDenominationAmount: Decimal.fromInt(100), tokenAliasModel: TestUtils.kexTokenAliasModel)),
+              tokenAmountModel: TokenAmountModel(defaultDenominationAmount: Decimal.fromInt(100), tokenAliasModel: TestUtils.kexTokenAliasModel)),
           MsgSendModel(
               fromWalletAddress: WalletAddress.fromBech32('kira143q8vxpvuykt9pq50e6hng9s38vmy844n8k9wx'),
               toWalletAddress: WalletAddress.fromBech32('kira143q8vxpvuykt9pq50e6hng9s38vmy844n8k9wx'),
-              tokenAmountModel: TokenAmountModel(lowestDenominationAmount: Decimal.fromInt(100), tokenAliasModel: TestUtils.kexTokenAliasModel)),
+              tokenAmountModel: TokenAmountModel(defaultDenominationAmount: Decimal.fromInt(100), tokenAliasModel: TestUtils.kexTokenAliasModel)),
         ],
       );
 
@@ -182,12 +182,12 @@ void main() {
         txDirectionType: TxDirectionType.outbound,
         txStatusType: TxStatusType.confirmed,
         fees: <TokenAmountModel>[
-          TokenAmountModel(lowestDenominationAmount: Decimal.fromInt(100), tokenAliasModel: TestUtils.kexTokenAliasModel),
+          TokenAmountModel(defaultDenominationAmount: Decimal.fromInt(100), tokenAliasModel: TestUtils.kexTokenAliasModel),
         ],
         prefixedTokenAmounts: <PrefixedTokenAmountModel>[
           PrefixedTokenAmountModel(
             tokenAmountPrefixType: TokenAmountPrefixType.subtract,
-            tokenAmountModel: TokenAmountModel(lowestDenominationAmount: Decimal.fromInt(100), tokenAliasModel: TestUtils.kexTokenAliasModel),
+            tokenAmountModel: TokenAmountModel(defaultDenominationAmount: Decimal.fromInt(100), tokenAliasModel: TestUtils.kexTokenAliasModel),
           ),
         ],
         txMsgModels: <ATxMsgModel>[],
@@ -205,19 +205,19 @@ void main() {
         txDirectionType: TxDirectionType.outbound,
         txStatusType: TxStatusType.confirmed,
         fees: <TokenAmountModel>[
-          TokenAmountModel(lowestDenominationAmount: Decimal.fromInt(100), tokenAliasModel: TestUtils.kexTokenAliasModel),
+          TokenAmountModel(defaultDenominationAmount: Decimal.fromInt(100), tokenAliasModel: TestUtils.kexTokenAliasModel),
         ],
         prefixedTokenAmounts: <PrefixedTokenAmountModel>[
           PrefixedTokenAmountModel(
             tokenAmountPrefixType: TokenAmountPrefixType.subtract,
-            tokenAmountModel: TokenAmountModel(lowestDenominationAmount: Decimal.fromInt(100), tokenAliasModel: TestUtils.kexTokenAliasModel),
+            tokenAmountModel: TokenAmountModel(defaultDenominationAmount: Decimal.fromInt(100), tokenAliasModel: TestUtils.kexTokenAliasModel),
           ),
         ],
         txMsgModels: <ATxMsgModel>[
           MsgSendModel(
               fromWalletAddress: WalletAddress.fromBech32('kira143q8vxpvuykt9pq50e6hng9s38vmy844n8k9wx'),
               toWalletAddress: WalletAddress.fromBech32('kira177lwmjyjds3cy7trers83r4pjn3dhv8zrqk9dl'),
-              tokenAmountModel: TokenAmountModel(lowestDenominationAmount: Decimal.fromInt(100), tokenAliasModel: TestUtils.kexTokenAliasModel)),
+              tokenAmountModel: TokenAmountModel(defaultDenominationAmount: Decimal.fromInt(100), tokenAliasModel: TestUtils.kexTokenAliasModel)),
         ],
       );
 
@@ -233,23 +233,23 @@ void main() {
         txDirectionType: TxDirectionType.outbound,
         txStatusType: TxStatusType.confirmed,
         fees: <TokenAmountModel>[
-          TokenAmountModel(lowestDenominationAmount: Decimal.fromInt(100), tokenAliasModel: TestUtils.kexTokenAliasModel),
+          TokenAmountModel(defaultDenominationAmount: Decimal.fromInt(100), tokenAliasModel: TestUtils.kexTokenAliasModel),
         ],
         prefixedTokenAmounts: <PrefixedTokenAmountModel>[
           PrefixedTokenAmountModel(
             tokenAmountPrefixType: TokenAmountPrefixType.subtract,
-            tokenAmountModel: TokenAmountModel(lowestDenominationAmount: Decimal.fromInt(100), tokenAliasModel: TestUtils.kexTokenAliasModel),
+            tokenAmountModel: TokenAmountModel(defaultDenominationAmount: Decimal.fromInt(100), tokenAliasModel: TestUtils.kexTokenAliasModel),
           ),
         ],
         txMsgModels: <ATxMsgModel>[
           MsgSendModel(
               fromWalletAddress: WalletAddress.fromBech32('kira143q8vxpvuykt9pq50e6hng9s38vmy844n8k9wx'),
               toWalletAddress: WalletAddress.fromBech32('kira177lwmjyjds3cy7trers83r4pjn3dhv8zrqk9dl'),
-              tokenAmountModel: TokenAmountModel(lowestDenominationAmount: Decimal.fromInt(100), tokenAliasModel: TestUtils.kexTokenAliasModel)),
+              tokenAmountModel: TokenAmountModel(defaultDenominationAmount: Decimal.fromInt(100), tokenAliasModel: TestUtils.kexTokenAliasModel)),
           MsgSendModel(
               fromWalletAddress: WalletAddress.fromBech32('kira143q8vxpvuykt9pq50e6hng9s38vmy844n8k9wx'),
               toWalletAddress: WalletAddress.fromBech32('kira143q8vxpvuykt9pq50e6hng9s38vmy844n8k9wx'),
-              tokenAmountModel: TokenAmountModel(lowestDenominationAmount: Decimal.fromInt(100), tokenAliasModel: TestUtils.kexTokenAliasModel)),
+              tokenAmountModel: TokenAmountModel(defaultDenominationAmount: Decimal.fromInt(100), tokenAliasModel: TestUtils.kexTokenAliasModel)),
         ],
       );
 

--- a/test/unit/shared/utils/transactions/tx_utils_test.dart
+++ b/test/unit/shared/utils/transactions/tx_utils_test.dart
@@ -172,14 +172,14 @@ Future<void> main() async {
       TxLocalInfoModel txLocalInfoModel = TxLocalInfoModel(
         memo: 'Test transaction',
         feeTokenAmountModel: TokenAmountModel(
-          lowestDenominationAmount: Decimal.fromInt(100),
+          defaultDenominationAmount: Decimal.fromInt(100),
           tokenAliasModel: TokenAliasModel.local('ukex'),
         ),
         txMsgModel: MsgSendModel(
           fromWalletAddress: TestUtils.wallet.address,
           toWalletAddress: WalletAddress.fromBech32('kira177lwmjyjds3cy7trers83r4pjn3dhv8zrqk9dl'),
           tokenAmountModel: TokenAmountModel(
-            lowestDenominationAmount: Decimal.fromInt(100),
+            defaultDenominationAmount: Decimal.fromInt(100),
             tokenAliasModel: TokenAliasModel.local('ukex'),
           ),
         ),


### PR DESCRIPTION
Bugfix: Default lowest denomination

The main goal for this branch is to set the lowest denomination as default and swap places of token denomination in transaction view. Previous order was from the highest to the lowest. After change, it is from the lowest to the highest. The additional goal for this branch is to globally refactor names of denomination models: defaultTokenDenomination -> networkTokenDenomination and lowestTokenDenomination -> defaultTokenDenomination.

List of changes:
- changed getter method with order of token denomination models to swap from lowest to highest in token_alias_model.dart
- changed factory return in token_form_state.dart from default token denomination to the lowest token denomination
- changed default token denomination model in token_form_cubit.dart and token_form_state.dart to the lowest token denomination model
- updated token amount preview widget, to use calculated token value based on selected denomination. Previously this widget contained simple getters, which didn't update widget when user changed denomination.
- renamed defaultTokenDenomination -> networkTokenDenomination and lowestTokenDenomination -> defaultTokenDenomination throughout the application