### PR TITLE
Bugfix: Proxy URL

### DIFF
--- a/assets/network_list_config.json
+++ b/assets/network_list_config.json
@@ -1,6 +1,6 @@
 {
   "refresh_interval_seconds": 60,
-  "proxy_server_url": "https://cors-anywhere.kira.network",
+  "proxy_server_url": "https://cors.kira.network",
   "network_list": [
     {
       "name": "Public Node 1",

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -12,7 +12,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 # In iOS, build-name is used as CFBundleShortVersionString while build-number used as CFBundleVersion.
 # Read more about iOS versioning at
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
-version: 1.21.1
+version: 1.21.2
 
 environment:
   sdk: ">=3.1.3"


### PR DESCRIPTION
Recently, infra team introduced a new proxy url, and old url has expired. The goal of this branch is to update it and check if it works properly.

List of changes:
- updated proxy_server_url from "https://cors-anywhere.kira.network" to "https://cors.kira.network" in network_list_config.json