### PR TITLE
Bugfix: Backdrop Drawer Flow

### DIFF
--- a/lib/views/layout/app_bar/account_button/connect_wallet_button/connect_wallet_button_mobile.dart
+++ b/lib/views/layout/app_bar/account_button/connect_wallet_button/connect_wallet_button_mobile.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:miro/config/app_icons.dart';
 import 'package:miro/config/theme/design_colors.dart';
+import 'package:miro/views/layout/scaffold/backdrop/backdrop.dart';
 import 'package:miro/views/layout/scaffold/kira_scaffold.dart';
 import 'package:miro/views/pages/drawer/sign_in_drawer_page/sign_in_drawer_page.dart';
 import 'package:miro/views/widgets/buttons/kira_elevated_button.dart';
@@ -18,8 +19,14 @@ class ConnectWalletButtonMobile extends StatelessWidget {
     return KiraElevatedButton(
       width: size.width,
       height: size.height,
-      onPressed: () => KiraScaffold.of(context).navigateEndDrawerRoute(const SignInDrawerPage()),
+      onPressed: () => _handleNavigation(context),
       icon: const Icon(AppIcons.account, color: DesignColors.background, size: 14),
     );
+  }
+
+  Future<void> _handleNavigation(BuildContext context) async {
+    KiraScaffold.of(context).navigateEndDrawerRoute(const SignInDrawerPage());
+    await Future<void>.delayed(const Duration(milliseconds: 500));
+    Backdrop.of(context).collapse();
   }
 }

--- a/lib/views/layout/app_bar/account_button/my_account_button/my_account_button_mobile.dart
+++ b/lib/views/layout/app_bar/account_button/my_account_button/my_account_button_mobile.dart
@@ -5,6 +5,7 @@ import 'package:miro/blocs/generic/identity_registrar/identity_registrar_cubit.d
 import 'package:miro/blocs/generic/identity_registrar/states/identity_registrar_loading_state.dart';
 import 'package:miro/config/locator.dart';
 import 'package:miro/shared/models/wallet/wallet.dart';
+import 'package:miro/views/layout/scaffold/backdrop/backdrop.dart';
 import 'package:miro/views/layout/scaffold/kira_scaffold.dart';
 import 'package:miro/views/pages/drawer/account_drawer_page/account_drawer_page.dart';
 import 'package:miro/views/widgets/kira/kira_identity_avatar.dart';
@@ -34,11 +35,17 @@ class MyAccountButtonMobile extends StatelessWidget {
         return MouseRegion(
           cursor: SystemMouseCursors.click,
           child: GestureDetector(
-            onTap: () => KiraScaffold.of(context).navigateEndDrawerRoute(AccountDrawerPage()),
+            onTap: () => _handleNavigation(context),
             child: buttonWidget,
           ),
         );
       },
     );
+  }
+
+  Future<void> _handleNavigation(BuildContext context) async {
+    KiraScaffold.of(context).navigateEndDrawerRoute(AccountDrawerPage());
+    await Future<void>.delayed(const Duration(milliseconds: 500));
+    Backdrop.of(context).collapse();
   }
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -12,7 +12,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 # In iOS, build-name is used as CFBundleShortVersionString while build-number used as CFBundleVersion.
 # Read more about iOS versioning at
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
-version: 1.21.3
+version: 1.21.4
 
 environment:
   sdk: ">=3.1.3"


### PR DESCRIPTION
The goal of this branch is to close Backdrop automatically (if open) when navigating to Sign In Drawer Page and Account Drawer Page on mobile view.

List of changes:
- extracted the navigation method to a private method in my_account_button_mobile.dart, connect_wallet_button_mobile.dart and added a call to the method that collapses the backdrop