### PR TITLE
Bugfix: Loading Page navigation

### DIFF
--- a/lib/blocs/generic/network_module/network_module_bloc.dart
+++ b/lib/blocs/generic/network_module/network_module_bloc.dart
@@ -107,6 +107,8 @@ class NetworkModuleBloc extends Bloc<ANetworkModuleEvent, NetworkModuleState> {
       await _networkCustomSectionCubit.updateNetworks(networkStatusModel);
       emit(NetworkModuleState.connected(networkStatusModel));
       _refreshTokenDefaultDenomModel(networkStatusModel);
+    } else {
+      await _networkCustomSectionCubit.updateNetworks();
     }
   }
 

--- a/lib/blocs/pages/loading/loading_page/loading_page_cubit.dart
+++ b/lib/blocs/pages/loading/loading_page/loading_page_cubit.dart
@@ -41,7 +41,6 @@ class LoadingPageCubit extends Cubit<ALoadingPageState> {
 
   void cancelConnection() {
     _networkModuleBloc.add(NetworkModuleDisconnectEvent());
-    emit(LoadingPageDisconnectedState());
   }
 
   Future<void> _init() async {

--- a/lib/blocs/widgets/network_list/network_custom_section/network_custom_section_cubit.dart
+++ b/lib/blocs/widgets/network_list/network_custom_section/network_custom_section_cubit.dart
@@ -51,7 +51,7 @@ class NetworkCustomSectionCubit extends Cubit<NetworkCustomSectionState> {
     }
   }
 
-  Future<void> updateNetworks(ANetworkStatusModel? connectedNetworkStatusModel) async {
+  Future<void> updateNetworks([ANetworkStatusModel? connectedNetworkStatusModel]) async {
     bool customNetworkBool = _isNetworkCustom(connectedNetworkStatusModel);
     bool differentNetworkBool = NetworkUtils.compareUrisByUrn(connectedNetworkStatusModel?.uri, state.connectedNetworkStatusModel?.uri) == false;
     bool checkedNetworkBool = NetworkUtils.compareUrisByUrn(connectedNetworkStatusModel?.uri, state.checkedNetworkStatusModel?.uri);

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -12,7 +12,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 # In iOS, build-name is used as CFBundleShortVersionString while build-number used as CFBundleVersion.
 # Read more about iOS versioning at
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
-version: 1.22.0
+version: 1.23.0
 
 environment:
   sdk: ">=3.1.3"


### PR DESCRIPTION
The purpose of this branch was to examine and fix the bug related to Loading Page navigation. It could occur at the start of the application, after clicking "Cancel connection" button and connecting to a network. In case of connecting to network from assets, there was an unexpected flipping view and the Value Notifier Exception was thrown. In case of connecting to custom network (but only unhealthy), the app navigated to DashboardPage with no network connected.

List of changes:
 - removed emit from "cancelConnection()" method in loading_page_cubit.dart. It was redundant, because adding NetworkModuleDisconnectEvent causes "_handleNetworkModuleStateChanged()", which then emits proper LoadingPageState - two states emitted in very short time caused flipping view. Also, the removed emit did not set value for NetworkModuleState, which caused "no network error".
 - modified "_mapAutoConnectEventToState()" method network_module_bloc.dart to prevent the "disconnected" status from being overwritten, in case of clicking "Cancel connection" button