### PR TITLE
Bugfix: Identity Registrar UI adjustments

### DIFF
--- a/lib/blocs/pages/transactions/tx_process_cubit/tx_process_cubit.dart
+++ b/lib/blocs/pages/transactions/tx_process_cubit/tx_process_cubit.dart
@@ -60,15 +60,21 @@ class TxProcessCubit<T extends AMsgFormModel> extends Cubit<ATxProcessState> {
       );
       if (formEnabledBool) {
         emit(txProcessLoadedState);
-      } else {
+        return;
+      }
+
+      SignedTxModel signedTxModel = await _buildSignedTransaction(feeTokenAmountModel);
+      if (isClosed == false) {
         emit(TxProcessConfirmState(
           txProcessLoadedState: txProcessLoadedState,
-          signedTxModel: await _buildSignedTransaction(feeTokenAmountModel),
+          signedTxModel: signedTxModel,
         ));
       }
     } catch (e) {
-      AppLogger().log(message: 'Failed to load transaction fee: $e');
-      emit(const TxProcessErrorState());
+      if (isClosed == false) {
+        AppLogger().log(message: 'Failed to load transaction fee: $e');
+        emit(const TxProcessErrorState());
+      }
     }
   }
 

--- a/lib/config/app_config.dart
+++ b/lib/config/app_config.dart
@@ -35,7 +35,7 @@ class AppConfig {
       defaultApiCacheMaxAge: const Duration(seconds: 60),
       outdatedBlockDuration: const Duration(minutes: 5),
       loadingPageTimerDuration: const Duration(seconds: 4),
-      supportedInterxVersions: <String>['v0.4.46'],
+      supportedInterxVersions: <String>['v0.4.46', 'v0.4.48'],
       rpcBrowserUrlController: RpcBrowserUrlController(),
       defaultRefreshIntervalSeconds: 60,
     );

--- a/lib/generated/intl/messages_en.dart
+++ b/lib/generated/intl/messages_en.dart
@@ -185,6 +185,7 @@ class MessageLookup extends MessageLookupByLibrary {
         "irUsername": MessageLookupByLibrary.simpleMessage("Username"),
         "irVerificationRequests":
             MessageLookupByLibrary.simpleMessage("Verification Requests"),
+        "irVerificationRequestsActions": MessageLookupByLibrary.simpleMessage("Actions"),
         "irVerificationRequestsApprove":
             MessageLookupByLibrary.simpleMessage("Approve"),
         "irVerificationRequestsApprovedRecord":
@@ -490,6 +491,7 @@ class MessageLookup extends MessageLookupByLibrary {
         "txHintUnstakeBy": MessageLookupByLibrary.simpleMessage("Unstake by"),
         "txHintUnstakeFrom":
             MessageLookupByLibrary.simpleMessage("Unstake from"),
+        "txHintVerifyBy": MessageLookupByLibrary.simpleMessage("Verify by"),
         "txIsBeingBroadcast": MessageLookupByLibrary.simpleMessage(
             "Your transaction is being broadcast"),
         "txListAmount": MessageLookupByLibrary.simpleMessage("Amount"),

--- a/lib/generated/l10n.dart
+++ b/lib/generated/l10n.dart
@@ -1,6 +1,7 @@
 // GENERATED CODE - DO NOT MODIFY BY HAND
 import 'package:flutter/material.dart';
 import 'package:intl/intl.dart';
+
 import 'intl/messages_all.dart';
 
 // **************************************************************************
@@ -18,17 +19,14 @@ class S {
   static S? _current;
 
   static S get current {
-    assert(_current != null,
-        'No instance of S was loaded. Try to initialize the S delegate before accessing S.current.');
+    assert(_current != null, 'No instance of S was loaded. Try to initialize the S delegate before accessing S.current.');
     return _current!;
   }
 
   static const AppLocalizationDelegate delegate = AppLocalizationDelegate();
 
   static Future<S> load(Locale locale) {
-    final name = (locale.countryCode?.isEmpty ?? false)
-        ? locale.languageCode
-        : locale.toString();
+    final name = (locale.countryCode?.isEmpty ?? false) ? locale.languageCode : locale.toString();
     final localeName = Intl.canonicalizedLocale(name);
     return initializeMessages(localeName).then((_) {
       Intl.defaultLocale = localeName;
@@ -41,8 +39,7 @@ class S {
 
   static S of(BuildContext context) {
     final instance = S.maybeOf(context);
-    assert(instance != null,
-        'No instance of S present in the widget tree. Did you add S.delegate in localizationsDelegates?');
+    assert(instance != null, 'No instance of S present in the widget tree. Did you add S.delegate in localizationsDelegates?');
     return instance!;
   }
 
@@ -675,6 +672,16 @@ class S {
     return Intl.message(
       'Verification Requests',
       name: 'irVerificationRequests',
+      desc: '',
+      args: [],
+    );
+  }
+
+  /// `Actions`
+  String get irVerificationRequestsActions {
+    return Intl.message(
+      'Actions',
+      name: 'irVerificationRequestsActions',
       desc: '',
       args: [],
     );
@@ -1641,8 +1648,7 @@ class S {
   }
 
   /// `Connecting to <{networkName}>{separator} Please wait... {parsedRemainingTime}`
-  String networkConnectingTo(
-      String separator, String networkName, String parsedRemainingTime) {
+  String networkConnectingTo(String separator, String networkName, String parsedRemainingTime) {
     return Intl.message(
       'Connecting to <$networkName>$separator Please wait... $parsedRemainingTime',
       name: 'networkConnectingTo',
@@ -2271,6 +2277,16 @@ class S {
     );
   }
 
+  /// `Verify by`
+  String get txHintVerifyBy {
+    return Intl.message(
+      'Verify by',
+      name: 'txHintVerifyBy',
+      desc: '',
+      args: [],
+    );
+  }
+
   /// `Transaction fee {widgetFeeTokenAmountModel}`
   String txNoticeFee(String widgetFeeTokenAmountModel) {
     return Intl.message(
@@ -2472,8 +2488,7 @@ class S {
   }
 
   /// `Available: {availableAmountText} {tokenDenominationModelName}`
-  String txAvailableBalances(
-      String availableAmountText, String tokenDenominationModelName) {
+  String txAvailableBalances(String availableAmountText, String tokenDenominationModelName) {
     return Intl.message(
       'Available: $availableAmountText $tokenDenominationModelName',
       name: 'txAvailableBalances',

--- a/lib/infra/services/api_kira/identity_records_service.dart
+++ b/lib/infra/services/api_kira/identity_records_service.dart
@@ -49,7 +49,7 @@ class IdentityRecordsService implements _IIdentityRecordsService {
       requestData: walletAddress.bech32Address,
       forceRequestBool: forceRequestBool,
     ));
-    List<PendingVerification> pendingVerifications = await _getAllPendingVerificationsByRequester(walletAddress);
+    List<PendingVerification> pendingVerifications = await _getAllPendingVerificationsByRequester(walletAddress, forceRequestBool: forceRequestBool);
 
     try {
       QueryIdentityRecordsByAddressResp queryIdentityRecordsByAddressResp = QueryIdentityRecordsByAddressResp.fromJson(response.data as Map<String, dynamic>);

--- a/lib/l10n/intl_en.arb
+++ b/lib/l10n/intl_en.arb
@@ -94,6 +94,7 @@
   "irRecordStatusPending": "Pending",
 
   "irVerificationRequests": "Verification Requests",
+  "irVerificationRequestsActions": "Actions",
   "irVerificationRequestsVerifyRecord": "Verify record",
   "irVerificationRequestsVerifyRecords": "Verify records",
   "irVerificationRequestsCreationDate": "Creation date",
@@ -298,6 +299,7 @@
   "txHintMemo": "Memo",
   "txHintUnstakeFrom": "Unstake from",
   "txHintUnstakeBy": "Unstake by",
+  "txHintVerifyBy": "Verify by",
   "txNoticeFee": "Transaction fee {widgetFeeTokenAmountModel}",
   "@txNoticeFee": {
     "placeholders": {

--- a/lib/views/pages/drawer/ir_verification_request_drawer_page/ir_verification_request_drawer_page.dart
+++ b/lib/views/pages/drawer/ir_verification_request_drawer_page/ir_verification_request_drawer_page.dart
@@ -10,8 +10,8 @@ import 'package:miro/shared/models/identity_registrar/ir_user_profile_model.dart
 import 'package:miro/shared/router/kira_router.dart';
 import 'package:miro/shared/router/router.gr.dart';
 import 'package:miro/views/layout/drawer/drawer_subtitle.dart';
-import 'package:miro/views/widgets/buttons/kira_elevated_button.dart';
-import 'package:miro/views/widgets/generic/account/account_tile.dart';
+import 'package:miro/views/widgets/buttons/kira_outlined_button.dart';
+import 'package:miro/views/widgets/generic/account_tile_copy_wrapper.dart';
 import 'package:miro/views/widgets/generic/expandable_text.dart';
 import 'package:miro/views/widgets/generic/prefixed_widget.dart';
 import 'package:miro/views/widgets/generic/responsive/responsive_value.dart';
@@ -44,15 +44,8 @@ class _IRVerificationRequestDrawerPage extends State<IRVerificationRequestDrawer
               ? S.of(context).irVerificationRequestsVerifyRecords
               : S.of(context).irVerificationRequestsVerifyRecord,
         ),
-        const SizedBox(height: 32),
-        AccountTile(
-          size: 52,
-          avatarUrl: requesterIrUserProfileModel.avatarUrl,
-          username: requesterIrUserProfileModel.username,
-          walletAddress: requesterIrUserProfileModel.walletAddress,
-          usernameTextStyle: textTheme.bodyLarge!.copyWith(color: DesignColors.white1),
-          addressTextStyle: textTheme.bodyMedium!.copyWith(color: DesignColors.white2),
-        ),
+        const SizedBox(height: 24),
+        AccountTileCopyWrapper.fromIRUserProfileModel(requesterIrUserProfileModel),
         const SizedBox(height: 8),
         const Divider(color: DesignColors.grey2),
         const SizedBox(height: 16),
@@ -70,6 +63,28 @@ class _IRVerificationRequestDrawerPage extends State<IRVerificationRequestDrawer
             widget.irInboundVerificationRequestModel.tipTokenAmountModel.toString(),
             style: textTheme.bodyMedium!.copyWith(color: DesignColors.white1),
           ),
+        ),
+        const SizedBox(height: 16),
+        Row(
+          children: <Widget>[
+            Expanded(
+              child: KiraOutlinedButton(
+                height: 40,
+                onPressed: _pressApproveButton,
+                title: S.of(context).irVerificationRequestsApprove,
+                textColor: DesignColors.greenStatus1,
+              ),
+            ),
+            const SizedBox(width: 16),
+            Expanded(
+              child: KiraOutlinedButton(
+                height: 40,
+                onPressed: _pressRejectButton,
+                title: S.of(context).irVerificationRequestsReject,
+                textColor: DesignColors.redStatus1,
+              ),
+            ),
+          ],
         ),
         const SizedBox(height: 16),
         PrefixedWidget(
@@ -128,29 +143,6 @@ class _IRVerificationRequestDrawerPage extends State<IRVerificationRequestDrawer
                   ),
                 ),
               const SizedBox(height: 16),
-              Row(
-                children: <Widget>[
-                  Expanded(
-                    child: KiraElevatedButton(
-                      height: 40,
-                      onPressed: _pressApproveButton,
-                      icon: const Icon(Icons.check, size: 20, color: DesignColors.greenStatus1),
-                      title: S.of(context).irVerificationRequestsApprove,
-                      foregroundColor: DesignColors.greenStatus1,
-                    ),
-                  ),
-                  const SizedBox(width: 16),
-                  Expanded(
-                    child: KiraElevatedButton(
-                      height: 40,
-                      onPressed: _pressRejectButton,
-                      icon: const Icon(Icons.close, size: 20, color: DesignColors.redStatus1),
-                      title: S.of(context).irVerificationRequestsReject,
-                      foregroundColor: DesignColors.redStatus1,
-                    ),
-                  ),
-                ],
-              )
             ],
           ),
         ),

--- a/lib/views/pages/menu/my_account_page/identity_registrar/identity_registrar_page.dart
+++ b/lib/views/pages/menu/my_account_page/identity_registrar/identity_registrar_page.dart
@@ -15,7 +15,7 @@ import 'package:miro/shared/models/identity_registrar/ir_record_model.dart';
 import 'package:miro/shared/models/wallet/wallet_address.dart';
 import 'package:miro/shared/router/kira_router.dart';
 import 'package:miro/shared/router/router.gr.dart';
-import 'package:miro/views/pages/menu/my_account_page/identity_registrar/ir_custom_entry_button.dart';
+import 'package:miro/views/pages/menu/my_account_page/identity_registrar/ir_custom_record_button.dart';
 import 'package:miro/views/pages/menu/my_account_page/identity_registrar/ir_record_tile/desktop/ir_record_tile_desktop_layout.dart';
 import 'package:miro/views/pages/menu/my_account_page/identity_registrar/ir_record_tile/ir_record_tile.dart';
 import 'package:miro/views/widgets/generic/responsive/responsive_widget.dart';
@@ -128,7 +128,7 @@ class _IdentityRegistrarPage extends State<IdentityRegistrarPage> {
                         ),
                       );
                     }).toList(),
-                    IRCustomEntryButton(onTap: () => _pressCustomEntryButton(identityRegistrarCubit)),
+                    IRCustomRecordButton(onTap: () => _pressCustomRecordButton(identityRegistrarCubit)),
                   ],
                 ),
               ),
@@ -139,12 +139,12 @@ class _IdentityRegistrarPage extends State<IdentityRegistrarPage> {
     );
   }
 
-  Future<void> _pressCustomEntryButton(IdentityRegistrarCubit identityRegistrarCubit) async {
+  Future<void> _pressCustomRecordButton(IdentityRegistrarCubit identityRegistrarCubit) async {
     await KiraRouter.of(context).push<void>(TransactionsWrapperRoute(
       children: <PageRouteInfo>[
         IRTxRegisterRecordRoute(irRecordModel: null, irKeyEditableBool: true),
       ],
     ));
-    await identityRegistrarCubit.refresh();
+    await identityRegistrarCubit.refresh(forceRequestBool: true);
   }
 }

--- a/lib/views/pages/menu/my_account_page/identity_registrar/ir_custom_record_button.dart
+++ b/lib/views/pages/menu/my_account_page/identity_registrar/ir_custom_record_button.dart
@@ -4,10 +4,10 @@ import 'package:miro/generated/l10n.dart';
 import 'package:miro/views/widgets/buttons/kira_text_button.dart';
 import 'package:miro/views/widgets/generic/responsive/responsive_value.dart';
 
-class IRCustomEntryButton extends StatelessWidget {
+class IRCustomRecordButton extends StatelessWidget {
   final VoidCallback onTap;
 
-  const IRCustomEntryButton({
+  const IRCustomRecordButton({
     required this.onTap,
     Key? key,
   }) : super(key: key);

--- a/lib/views/pages/menu/my_account_page/identity_registrar/ir_record_tile/ir_record_tile.dart
+++ b/lib/views/pages/menu/my_account_page/identity_registrar/ir_record_tile/ir_record_tile.dart
@@ -87,7 +87,7 @@ class _IdentityRecordTile extends State<IRRecordTile> {
       children: <PageRouteInfo>[
         IRTxRegisterRecordRoute(
           irRecordModel: widget.irRecordModel,
-          irKeyEditableBool: widget.irRecordModel?.key.isNotEmpty == true,
+          irKeyEditableBool: false,
           irValueMaxLength: widget.irRecordFieldConfigModel.valueMaxLength,
         )
       ],

--- a/lib/views/pages/menu/my_account_page/identity_registrar/ir_record_tile/mobile/ir_record_tile_mobile.dart
+++ b/lib/views/pages/menu/my_account_page/identity_registrar/ir_record_tile/mobile/ir_record_tile_mobile.dart
@@ -75,7 +75,7 @@ class IRRecordTileMobile extends StatelessWidget {
               onPressed: onShowDrawerPressed,
             ),
           ],
-          const SizedBox(height: 16),
+          const SizedBox(height: 14),
           Row(
             crossAxisAlignment: CrossAxisAlignment.center,
             children: <Widget>[
@@ -83,24 +83,24 @@ class IRRecordTileMobile extends StatelessWidget {
                 Expanded(
                   child: KiraOutlinedButton(
                     height: 40,
+                    title: S.of(context).irRecordVerify,
+                    onPressed: onVerifyPressed,
+                  ),
+                ),
+                const SizedBox(width: 14),
+                Expanded(
+                  child: KiraOutlinedButton(
+                    height: 40,
                     title: S.of(context).irRecordEdit,
                     onPressed: onEditPressed,
                   ),
                 ),
-                const SizedBox(width: 15),
+                const SizedBox(width: 14),
                 Expanded(
                   child: KiraOutlinedButton(
                     height: 40,
                     title: S.of(context).irRecordDelete,
                     onPressed: onDeletePressed,
-                  ),
-                ),
-                const SizedBox(width: 15),
-                Expanded(
-                  child: KiraOutlinedButton(
-                    height: 40,
-                    title: S.of(context).irRecordVerify,
-                    onPressed: onVerifyPressed,
                   ),
                 ),
               ] else if (loadingBool == false)

--- a/lib/views/pages/menu/my_account_page/staking_page/staking_list_item/mobile/staking_list_item_mobile.dart
+++ b/lib/views/pages/menu/my_account_page/staking_page/staking_list_item/mobile/staking_list_item_mobile.dart
@@ -92,7 +92,7 @@ class _StakingListItemMobile extends State<StakingListItemMobile> {
               StakingDrawerPage(validatorStakingModel: widget.validatorStakingModel),
             ),
           ),
-          const SizedBox(height: 18),
+          const SizedBox(height: 14),
           SizedBox(
             height: 40,
             child: Row(
@@ -103,7 +103,7 @@ class _StakingListItemMobile extends State<StakingListItemMobile> {
                     onPressed: _handleStakeButtonPressed,
                   ),
                 ),
-                const SizedBox(width: 12),
+                const SizedBox(width: 14),
                 Expanded(
                   child: KiraOutlinedButton(
                     title: S.of(context).stakingTxUnstake,

--- a/lib/views/pages/menu/my_account_page/verification_requests/verification_request_list_item/desktop/verification_request_list_item_desktop.dart
+++ b/lib/views/pages/menu/my_account_page/verification_requests/verification_request_list_item/desktop/verification_request_list_item_desktop.dart
@@ -1,16 +1,22 @@
 import 'package:flutter/material.dart';
 import 'package:intl/intl.dart';
 import 'package:miro/config/theme/design_colors.dart';
+import 'package:miro/generated/l10n.dart';
 import 'package:miro/shared/models/identity_registrar/ir_inbound_verification_request_model.dart';
 import 'package:miro/shared/models/identity_registrar/ir_user_profile_model.dart';
 import 'package:miro/views/pages/menu/my_account_page/verification_requests/verification_request_list_item/desktop/verification_request_list_item_desktop_layout.dart';
+import 'package:miro/views/widgets/buttons/kira_outlined_button.dart';
 import 'package:miro/views/widgets/generic/account/account_tile.dart';
 
 class VerificationRequestListItemDesktop extends StatelessWidget {
+  final VoidCallback onApproveButtonPressed;
+  final VoidCallback onRejectButtonPressed;
   final VoidCallback onShowDrawerPressed;
   final IRInboundVerificationRequestModel irInboundVerificationRequestModel;
 
   const VerificationRequestListItemDesktop({
+    required this.onApproveButtonPressed,
+    required this.onRejectButtonPressed,
     required this.onShowDrawerPressed,
     required this.irInboundVerificationRequestModel,
     Key? key,
@@ -51,6 +57,31 @@ class VerificationRequestListItemDesktop extends StatelessWidget {
       tipWidget: Text(
         irInboundVerificationRequestModel.tipTokenAmountModel.toString(),
         style: textTheme.bodyMedium!.copyWith(color: DesignColors.white2),
+      ),
+      actionsWidget: SizedBox(
+        height: 40,
+        child: Row(
+          children: <Widget>[
+            Expanded(
+              child: KiraOutlinedButton(
+                height: 40,
+                onPressed: onApproveButtonPressed,
+                title: S.of(context).irVerificationRequestsApprove,
+                textColor: DesignColors.greenStatus1,
+              ),
+            ),
+            const SizedBox(width: 12),
+            Expanded(
+              child: KiraOutlinedButton(
+                height: 40,
+                onPressed: onRejectButtonPressed,
+                title: S.of(context).irVerificationRequestsReject,
+                textColor: DesignColors.redStatus1,
+              ),
+            ),
+            const SizedBox(width: 12),
+          ],
+        ),
       ),
     );
   }

--- a/lib/views/pages/menu/my_account_page/verification_requests/verification_request_list_item/desktop/verification_request_list_item_desktop_layout.dart
+++ b/lib/views/pages/menu/my_account_page/verification_requests/verification_request_list_item/desktop/verification_request_list_item_desktop_layout.dart
@@ -6,6 +6,7 @@ class VerificationRequestListItemDesktopLayout extends StatelessWidget {
   final Widget dateWidget;
   final Widget keysWidget;
   final Widget tipWidget;
+  final Widget actionsWidget;
   final double? height;
 
   const VerificationRequestListItemDesktopLayout({
@@ -14,6 +15,7 @@ class VerificationRequestListItemDesktopLayout extends StatelessWidget {
     required this.dateWidget,
     required this.keysWidget,
     required this.tipWidget,
+    required this.actionsWidget,
     this.height,
     Key? key,
   }) : super(key: key);
@@ -40,6 +42,8 @@ class VerificationRequestListItemDesktopLayout extends StatelessWidget {
           Expanded(flex: 3, child: keysWidget),
           const Spacer(flex: 1),
           Expanded(flex: 3, child: tipWidget),
+          const Spacer(flex: 1),
+          Expanded(flex: 6, child: actionsWidget),
         ],
       ),
     );

--- a/lib/views/pages/menu/my_account_page/verification_requests/verification_request_list_item/mobile/verification_request_list_item_mobile.dart
+++ b/lib/views/pages/menu/my_account_page/verification_requests/verification_request_list_item/mobile/verification_request_list_item_mobile.dart
@@ -9,10 +9,14 @@ import 'package:miro/views/widgets/generic/account/account_tile.dart';
 import 'package:miro/views/widgets/generic/prefixed_widget.dart';
 
 class VerificationRequestListItemMobile extends StatelessWidget {
+  final VoidCallback onApproveButtonPressed;
+  final VoidCallback onRejectButtonPressed;
   final VoidCallback onShowDrawerPressed;
   final IRInboundVerificationRequestModel irInboundVerificationRequestModel;
 
   const VerificationRequestListItemMobile({
+    required this.onApproveButtonPressed,
+    required this.onRejectButtonPressed,
     required this.onShowDrawerPressed,
     required this.irInboundVerificationRequestModel,
     Key? key,
@@ -81,6 +85,28 @@ class VerificationRequestListItemMobile extends StatelessWidget {
             height: 40,
             title: S.of(context).showDetails,
             onPressed: onShowDrawerPressed,
+          ),
+          const SizedBox(height: 14),
+          Row(
+            children: <Widget>[
+              Expanded(
+                child: KiraOutlinedButton(
+                  height: 40,
+                  onPressed: onApproveButtonPressed,
+                  title: S.of(context).irVerificationRequestsApprove,
+                  textColor: DesignColors.greenStatus1,
+                ),
+              ),
+              const SizedBox(width: 14),
+              Expanded(
+                child: KiraOutlinedButton(
+                  height: 40,
+                  onPressed: onRejectButtonPressed,
+                  title: S.of(context).irVerificationRequestsReject,
+                  textColor: DesignColors.redStatus1,
+                ),
+              ),
+            ],
           ),
         ],
       ),

--- a/lib/views/pages/menu/my_account_page/verification_requests/verification_request_list_item/verification_request_list_item_builder.dart
+++ b/lib/views/pages/menu/my_account_page/verification_requests/verification_request_list_item/verification_request_list_item_builder.dart
@@ -1,8 +1,12 @@
+import 'package:auto_route/auto_route.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:miro/blocs/widgets/kira/kira_list/abstract_list/events/list_reload_event.dart';
 import 'package:miro/blocs/widgets/kira/kira_list/infinity_list/infinity_list_bloc.dart';
 import 'package:miro/shared/models/identity_registrar/ir_inbound_verification_request_model.dart';
+import 'package:miro/shared/router/kira_router.dart';
+import 'package:miro/shared/router/router.gr.dart';
 import 'package:miro/views/layout/scaffold/kira_scaffold.dart';
 import 'package:miro/views/pages/drawer/ir_verification_request_drawer_page/ir_verification_request_drawer_page.dart';
 import 'package:miro/views/pages/menu/my_account_page/verification_requests/verification_request_list_item/desktop/verification_request_list_item_desktop.dart';
@@ -25,11 +29,15 @@ class _VerificationRequestListItemBuilder extends State<VerificationRequestListI
   @override
   Widget build(BuildContext context) {
     Widget desktopListItem = VerificationRequestListItemDesktop(
+      onApproveButtonPressed: _pressApproveButton,
+      onRejectButtonPressed: _pressRejectButton,
       onShowDrawerPressed: _pressShowDrawerButton,
       irInboundVerificationRequestModel: widget.irInboundVerificationRequestModel,
     );
 
     Widget mobileListItem = VerificationRequestListItemMobile(
+      onApproveButtonPressed: _pressApproveButton,
+      onRejectButtonPressed: _pressRejectButton,
       onShowDrawerPressed: _pressShowDrawerButton,
       irInboundVerificationRequestModel: widget.irInboundVerificationRequestModel,
     );
@@ -39,6 +47,27 @@ class _VerificationRequestListItemBuilder extends State<VerificationRequestListI
       mediumScreen: mobileListItem,
       smallScreen: mobileListItem,
     );
+  }
+
+  void _pressApproveButton() {
+    _openTransactionPage(approvalStatusBool: true, context: context);
+  }
+
+  void _pressRejectButton() {
+    _openTransactionPage(approvalStatusBool: false, context: context);
+  }
+
+  Future<void> _openTransactionPage({required bool approvalStatusBool, required BuildContext context}) async {
+    await KiraRouter.of(context).push<void>(TransactionsWrapperRoute(
+      children: <PageRouteInfo>[
+        IRTxHandleVerificationRequestRoute(
+          approvalStatusBool: approvalStatusBool,
+          irInboundVerificationRequestModel: widget.irInboundVerificationRequestModel,
+        ),
+      ],
+    ));
+
+    BlocProvider.of<InfinityListBloc<IRInboundVerificationRequestModel>>(context).add(const ListReloadEvent(forceRequestBool: true));
   }
 
   void _pressShowDrawerButton() {

--- a/lib/views/pages/menu/my_account_page/verification_requests/verification_requests_page.dart
+++ b/lib/views/pages/menu/my_account_page/verification_requests/verification_requests_page.dart
@@ -62,13 +62,13 @@ class _VerificationRequestsPage extends State<VerificationRequestsPage> {
         ),
       ),
       child: VerificationRequestListItemDesktopLayout(
-        height: 53,
-        infoButtonWidget: const SizedBox(),
-        requesterAddressWidget: Text(S.of(context).irVerificationRequestsFrom, style: textTheme.bodySmall!.copyWith(color: DesignColors.white1)),
-        dateWidget: Text(S.of(context).irVerificationRequestsCreationDate, style: textTheme.bodySmall!.copyWith(color: DesignColors.white1)),
-        keysWidget: Text(S.of(context).irVerificationRequestsRecords, style: textTheme.bodySmall!.copyWith(color: DesignColors.white1)),
-        tipWidget: Text(S.of(context).irVerificationRequestsTip, style: textTheme.bodySmall!.copyWith(color: DesignColors.white1)),
-      ),
+          height: 53,
+          infoButtonWidget: const SizedBox(),
+          requesterAddressWidget: Text(S.of(context).irVerificationRequestsFrom, style: textTheme.bodySmall!.copyWith(color: DesignColors.white1)),
+          dateWidget: Text(S.of(context).irVerificationRequestsCreationDate, style: textTheme.bodySmall!.copyWith(color: DesignColors.white1)),
+          keysWidget: Text(S.of(context).irVerificationRequestsRecords, style: textTheme.bodySmall!.copyWith(color: DesignColors.white1)),
+          tipWidget: Text(S.of(context).irVerificationRequestsTip, style: textTheme.bodySmall!.copyWith(color: DesignColors.white1)),
+          actionsWidget: Text(S.of(context).irVerificationRequestsActions, style: textTheme.bodySmall!.copyWith(color: DesignColors.white1))),
     );
 
     return SliverInfinityList<IRInboundVerificationRequestModel>(

--- a/lib/views/pages/transactions/msg_forms/ir_msg_register_record_form/ir_msg_register_record_form.dart
+++ b/lib/views/pages/transactions/msg_forms/ir_msg_register_record_form/ir_msg_register_record_form.dart
@@ -7,7 +7,6 @@ import 'package:miro/shared/models/wallet/wallet_address.dart';
 import 'package:miro/shared/utils/string_utils.dart';
 import 'package:miro/views/pages/transactions/msg_forms/ir_msg_register_record_form/ir_key_text_input_formatter.dart';
 import 'package:miro/views/widgets/generic/responsive/responsive_value.dart';
-import 'package:miro/views/widgets/transactions/memo_text_field/memo_text_field.dart';
 import 'package:miro/views/widgets/transactions/tx_input_wrapper.dart';
 import 'package:miro/views/widgets/transactions/tx_text_field.dart';
 import 'package:miro/views/widgets/transactions/wallet_address_text_field.dart';
@@ -90,19 +89,8 @@ class _IRMsgRegisterRecordForm extends State<IRMsgRegisterRecordForm> {
             ),
           ),
           const SizedBox(height: 14),
-          if (widget.irValueMaxLength != null)
-            MemoTextField(
-              label: S.of(context).irTxHintValue,
-              onChanged: _handleValueChanged,
-              memoTextEditingController: identityValueTextEditingController,
-              maxLength: widget.irValueMaxLength!,
-              inputFormatters: <TextInputFormatter>[
-                FilteringTextInputFormatter.allow(StringUtils.irUsernameRegExp),
-              ],
-            )
-          else
-            TxInputWrapper(
-              boxConstraints: BoxConstraints(
+          TxInputWrapper(
+            boxConstraints: BoxConstraints(
                 minHeight: 60,
                 maxHeight: const ResponsiveValue<double>(largeScreen: 200, smallScreen: 125).get(context),
               ),
@@ -116,12 +104,6 @@ class _IRMsgRegisterRecordForm extends State<IRMsgRegisterRecordForm> {
                 onChanged: _handleValueChanged,
               ),
             ),
-          const SizedBox(height: 19),
-          MemoTextField(
-            label: S.of(context).txHintMemo,
-            onChanged: _handleMemoChanged,
-            memoTextEditingController: memoTextEditingController,
-          ),
         ],
       ),
     );
@@ -150,9 +132,5 @@ class _IRMsgRegisterRecordForm extends State<IRMsgRegisterRecordForm> {
 
   void _handleValueChanged(String value) {
     widget.irMsgRegisterRecordFormModel.identityValue = value;
-  }
-
-  void _handleMemoChanged(String memo) {
-    widget.irMsgRegisterRecordFormModel.memo = memo;
   }
 }

--- a/lib/views/pages/transactions/msg_forms/ir_msg_register_record_form/ir_msg_register_record_form_preview.dart
+++ b/lib/views/pages/transactions/msg_forms/ir_msg_register_record_form/ir_msg_register_record_form_preview.dart
@@ -48,11 +48,6 @@ class _IRMsgRegisterRecordFormPreview extends State<IRMsgRegisterRecordFormPrevi
           label: S.of(context).irTxHintValue,
           value: iRMsgRegisterRecordsModel.irEntryModels.first.info,
         ),
-        const SizedBox(height: 28),
-        TxInputPreview(
-          label: S.of(context).txHintMemo,
-          value: widget.txLocalInfoModel.memo,
-        ),
         const SizedBox(height: 15),
         const Divider(color: DesignColors.grey2),
         const SizedBox(height: 15),

--- a/lib/views/pages/transactions/msg_forms/ir_msg_request_verification_form/ir_msg_request_verification_form.dart
+++ b/lib/views/pages/transactions/msg_forms/ir_msg_request_verification_form/ir_msg_request_verification_form.dart
@@ -63,7 +63,7 @@ class _IRMsgRequestVerificationForm extends State<IRMsgRequestVerificationForm> 
           ),
           const SizedBox(height: 14),
           WalletAddressTextField(
-            label: S.of(context).txHintSendTo,
+            label: S.of(context).txHintVerifyBy,
             onChanged: _handleVerifierAddressChanged,
             defaultWalletAddress: widget.irMsgRequestVerificationFormModel.verifierWalletAddress,
           ),

--- a/lib/views/widgets/buttons/kira_outlined_button.dart
+++ b/lib/views/widgets/buttons/kira_outlined_button.dart
@@ -10,6 +10,7 @@ class KiraOutlinedButton extends StatelessWidget {
   final bool disabled;
   final bool uppercaseBool;
   final Color? borderColor;
+  final Color? textColor;
   final Widget? leading;
   final Widget? trailing;
 
@@ -21,6 +22,7 @@ class KiraOutlinedButton extends StatelessWidget {
     this.disabled = false,
     this.uppercaseBool = true,
     this.borderColor,
+    this.textColor,
     this.leading,
     this.trailing,
     Key? key,
@@ -56,7 +58,7 @@ class KiraOutlinedButton extends StatelessWidget {
                   uppercaseBool ? title.toUpperCase() : title,
                   textAlign: TextAlign.center,
                   style: textTheme.labelLarge!.copyWith(
-                    color: DesignColors.white1,
+                    color: _getTextColor(states),
                   ),
                 ),
                 if (trailing != null) ...<Widget>[const SizedBox(width: 4), trailing!],
@@ -72,7 +74,14 @@ class KiraOutlinedButton extends StatelessWidget {
     if (states.contains(MaterialState.hovered) && disabled == false) {
       return DesignColors.white1;
     }
-    return borderColor ?? DesignColors.greyOutline;
+    return borderColor ?? textColor?.withOpacity(0.5) ?? DesignColors.greyOutline;
+  }
+
+  Color _getTextColor(Set<MaterialState> states) {
+    if (states.contains(MaterialState.hovered)) {
+      return DesignColors.white1;
+    }
+    return textColor ?? DesignColors.white1;
   }
 
   Color _getBackgroundColor(Set<MaterialState> states) {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -12,7 +12,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 # In iOS, build-name is used as CFBundleShortVersionString while build-number used as CFBundleVersion.
 # Read more about iOS versioning at
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
-version: 1.25.0
+version: 1.25.1
 
 environment:
   sdk: ">=3.1.3"


### PR DESCRIPTION
The main goal of this bugfix was to adjust IdentityRegistrarPage and VerificationRequestsPage for better user experience. Among IR page changed button order of existing IR records, changed form of "Add/Register record" and "Edit" by removing memo TextField, also blocked key editing in existing record. In VerificationRequestsPage added approve and reject buttons in every element of list to make easier and faster actions on requests. Also edited details of record by adding address copying and moving buttons from bottom of drawer to below tip label.

List of changes:
- modified kira_outlined_button.dart to enable specifying color for text and border
- added approve and reject buttons in VerificationRequestPage on both desktop and mobile for each list item
- added copy button and address details in IRVerificationRequestDrawerPage to make it more generic like in ValidatorsDrawerPage
- blocked "key" TextField from editing in ir_msg_register_record_form.dart
- changed buttons order in ir_record_tile_mobile.dart from “Edit”, “Verify”, “Delete” to “Verify”, “Edit”, “Delete”
- changed "Approve" and "Reject" buttons position in ir_verification_request_drawer_page.dart from bottom of drawer to below of tip label
- changed TextField in ir_msg_request_verification_form.dart from "Send to" to "Verify by"
- removed memo from ir_msg_register_record_form.dart both in "Add/Register" and "Edit" record form