### PR TITLE
Feature: Default network token display

### DIFF
--- a/lib/blocs/widgets/kira/kira_list/abstract_list/a_list_bloc.dart
+++ b/lib/blocs/widgets/kira/kira_list/abstract_list/a_list_bloc.dart
@@ -105,11 +105,17 @@ abstract class AListBloc<T extends AListItem> extends Bloc<AListEvent, AListStat
       return listItems;
     }
     SortOption<T> activeSortOption = sortBloc!.state.activeSortOption;
-    List<T> favouritesList = favouritesBloc?.favouritesList ?? <T>[];
-    Set<T> uniqueListItems = <T>{
-      ...activeSortOption.sort(filterList(favouritesList.toSet().toList())),
-      ...activeSortOption.sort(listItems),
-    };
+    List<T> favouritesList = favouritesBloc?.favouritesList.toSet().toList() ?? <T>[];
+    List<T> sortedList = activeSortOption.sort(listItems);
+
+    Set<T> uniqueListItems = activeSortOption.sort(filterList(favouritesList)).toSet();
+
+    for (T item in sortedList) {
+      if (uniqueListItems.contains(item) == false) {
+        uniqueListItems.add(item);
+      }
+    }
+
     return uniqueListItems.toList();
   }
 

--- a/lib/blocs/widgets/kira/kira_list/abstract_list/models/page_data.dart
+++ b/lib/blocs/widgets/kira/kira_list/abstract_list/models/page_data.dart
@@ -19,6 +19,20 @@ class PageData<T> extends Equatable {
         cacheExpirationDateTime = null,
         lastPageBool = false;
 
+  PageData<T> copyWith({
+    List<T>? listItems,
+    bool? lastPageBool,
+    DateTime? blockDateTime,
+    DateTime? cacheExpirationDateTime,
+  }) {
+    return PageData<T>(
+      listItems: listItems ?? this.listItems,
+      lastPageBool: lastPageBool ?? this.lastPageBool,
+      blockDateTime: blockDateTime ?? this.blockDateTime,
+      cacheExpirationDateTime: cacheExpirationDateTime ?? this.cacheExpirationDateTime,
+    );
+  }
+
   @override
   List<Object?> get props => <Object?>[listItems, lastPageBool, blockDateTime, cacheExpirationDateTime];
 }

--- a/lib/views/pages/menu/my_account_page/balance_page/balance_list_item/balance_list_item_builder.dart
+++ b/lib/views/pages/menu/my_account_page/balance_page/balance_list_item/balance_list_item_builder.dart
@@ -18,10 +18,12 @@ import 'package:miro/views/widgets/generic/responsive/responsive_widget.dart';
 class BalanceListItemBuilder extends StatefulWidget {
   final BalanceModel balanceModel;
   final ScrollController scrollController;
+  final bool sendButtonActiveBool;
 
   const BalanceListItemBuilder({
     required this.balanceModel,
     required this.scrollController,
+    required this.sendButtonActiveBool,
     Key? key,
   }) : super(key: key);
 
@@ -52,6 +54,7 @@ class _BalanceListItemBuilder extends State<BalanceListItemBuilder> {
           favouritePressedCallback: _onFavouriteButtonPressed,
           onSendButtonPressed: _handleSendButtonPressed,
           hoverNotifier: hoverNotifier,
+          sendButtonActiveBool: widget.sendButtonActiveBool,
         ),
         mediumScreen: BalanceListItemMobile(
           balanceModel: widget.balanceModel,
@@ -59,6 +62,7 @@ class _BalanceListItemBuilder extends State<BalanceListItemBuilder> {
           favouritePressedCallback: _onFavouriteButtonPressed,
           hoverNotifier: hoverNotifier,
           onSendButtonPressed: _handleSendButtonPressed,
+          sendButtonActiveBool: widget.sendButtonActiveBool,
         ),
       ),
     );

--- a/lib/views/pages/menu/my_account_page/balance_page/balance_list_item/desktop/balance_list_item_desktop.dart
+++ b/lib/views/pages/menu/my_account_page/balance_page/balance_list_item/desktop/balance_list_item_desktop.dart
@@ -11,6 +11,7 @@ class BalanceListItemDesktop extends StatelessWidget {
   final ValueNotifier<bool> hoverNotifier;
   final VoidCallback onSendButtonPressed;
   final double sectionsSpace;
+  final bool sendButtonActiveBool;
 
   const BalanceListItemDesktop({
     required this.balanceModel,
@@ -18,6 +19,7 @@ class BalanceListItemDesktop extends StatelessWidget {
     required this.favouritePressedCallback,
     required this.hoverNotifier,
     required this.onSendButtonPressed,
+    required this.sendButtonActiveBool,
     this.sectionsSpace = 15,
     Key? key,
   }) : super(key: key);
@@ -38,6 +40,7 @@ class BalanceListItemDesktop extends StatelessWidget {
         hoverNotifier: hoverNotifier,
         favouritePressedCallback: favouritePressedCallback,
         onSendButtonPressed: onSendButtonPressed,
+        sendButtonActiveBool: sendButtonActiveBool,
         sectionsSpace: sectionsSpace,
       ),
       children: <Widget>[

--- a/lib/views/pages/menu/my_account_page/balance_page/balance_list_item/desktop/balance_list_item_desktop_title.dart
+++ b/lib/views/pages/menu/my_account_page/balance_page/balance_list_item/desktop/balance_list_item_desktop_title.dart
@@ -11,6 +11,7 @@ class BalanceListItemDesktopTitle extends StatelessWidget {
   final ValueChanged<bool> favouritePressedCallback;
   final ValueNotifier<bool> hoverNotifier;
   final VoidCallback onSendButtonPressed;
+  final bool sendButtonActiveBool;
 
   const BalanceListItemDesktopTitle({
     required this.sectionsSpace,
@@ -18,6 +19,7 @@ class BalanceListItemDesktopTitle extends StatelessWidget {
     required this.favouritePressedCallback,
     required this.hoverNotifier,
     required this.onSendButtonPressed,
+    required this.sendButtonActiveBool,
     Key? key,
   }) : super(key: key);
 
@@ -62,7 +64,8 @@ class BalanceListItemDesktopTitle extends StatelessWidget {
         KiraOutlinedButton(
           height: 40,
           width: 70,
-          onPressed: onSendButtonPressed,
+          disabled: sendButtonActiveBool == false,
+          onPressed: sendButtonActiveBool ? onSendButtonPressed : null,
           title: S.of(context).balancesSend,
         ),
       ],

--- a/lib/views/pages/menu/my_account_page/balance_page/balance_list_item/mobile/balance_list_item_mobile.dart
+++ b/lib/views/pages/menu/my_account_page/balance_page/balance_list_item/mobile/balance_list_item_mobile.dart
@@ -12,6 +12,7 @@ class BalanceListItemMobile extends StatelessWidget {
   final ValueChanged<bool> favouritePressedCallback;
   final ValueNotifier<bool> hoverNotifier;
   final VoidCallback onSendButtonPressed;
+  final bool sendButtonActiveBool;
 
   const BalanceListItemMobile({
     required this.balanceModel,
@@ -19,6 +20,7 @@ class BalanceListItemMobile extends StatelessWidget {
     required this.favouritePressedCallback,
     required this.hoverNotifier,
     required this.onSendButtonPressed,
+    required this.sendButtonActiveBool,
     Key? key,
   }) : super(key: key);
 
@@ -51,7 +53,8 @@ class BalanceListItemMobile extends StatelessWidget {
           child: KiraOutlinedButton(
             height: 40,
             width: double.infinity,
-            onPressed: onSendButtonPressed,
+            disabled: sendButtonActiveBool == false,
+            onPressed: sendButtonActiveBool ? onSendButtonPressed : null,
             title: S.of(context).balancesSend,
           ),
         ),

--- a/lib/views/pages/menu/my_account_page/balance_page/balance_page.dart
+++ b/lib/views/pages/menu/my_account_page/balance_page/balance_page.dart
@@ -1,3 +1,4 @@
+import 'package:decimal/decimal.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:miro/blocs/widgets/kira/kira_list/favourites/favourites_bloc.dart';
@@ -57,6 +58,7 @@ class _BalancePage extends State<BalancePage> {
 
     return SliverInfinityList<BalanceModel>(
       itemBuilder: (BalanceModel balanceModel) => BalanceListItemBuilder(
+        sendButtonActiveBool: balanceModel.tokenAmountModel.getAmountInDefaultDenomination() != Decimal.zero,
         key: Key('${balanceModel.hashCode}'),
         balanceModel: balanceModel,
         scrollController: widget.parentScrollController,

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -12,7 +12,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 # In iOS, build-name is used as CFBundleShortVersionString while build-number used as CFBundleVersion.
 # Read more about iOS versioning at
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
-version: 1.27.0
+version: 1.28.0
 
 environment:
   sdk: ">=3.1.3"


### PR DESCRIPTION
Branch adds display of default network token in balance_page.dart when account doesn't have any tokens.

List of changes:
- modified balances_list_controller.dart by updating getPageData() method with check-up of account balances if there are any tokens. If there are no tokens then default network token is added with value equal zero.
- modified a_list_block.dart by updating sort method for proper sorting because previously if the default balance was in favorites, corresponding non-favorite element would still be added to Set and overwrite favorite element.