### PR TITLE
Bugfix: Favourite balance refresh

### DIFF
--- a/lib/blocs/widgets/kira/kira_list/abstract_list/a_list_bloc.dart
+++ b/lib/blocs/widgets/kira/kira_list/abstract_list/a_list_bloc.dart
@@ -1,4 +1,4 @@
-import 'dart:async';
+ import 'dart:async';
 
 import 'package:flutter/cupertino.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
@@ -149,7 +149,7 @@ abstract class AListBloc<T extends AListItem> extends Bloc<AListEvent, AListStat
     currentPageData = PageData<T>.initial();
     lastPageIndex = 0;
 
-    await favouritesBloc?.initFavourites();
+    await favouritesBloc?.initFavourites(forceRequestBool: true);
 
     bool filtersEnabledBool = filtersBloc?.state is FiltersActiveState<T>;
     bool sortEnabledBool = sortBloc != null;

--- a/lib/blocs/widgets/kira/kira_list/infinity_list/infinity_list_bloc.dart
+++ b/lib/blocs/widgets/kira/kira_list/infinity_list/infinity_list_bloc.dart
@@ -7,6 +7,7 @@ import 'package:miro/blocs/widgets/kira/kira_list/abstract_list/events/list_upda
 import 'package:miro/blocs/widgets/kira/kira_list/abstract_list/models/a_list_item.dart';
 import 'package:miro/blocs/widgets/kira/kira_list/abstract_list/models/page_data.dart';
 import 'package:miro/blocs/widgets/kira/kira_list/abstract_list/states/list_loaded_state.dart';
+import 'package:miro/blocs/widgets/kira/kira_list/abstract_list/states/list_loading_state.dart';
 import 'package:miro/blocs/widgets/kira/kira_list/favourites/favourites_bloc.dart';
 import 'package:miro/blocs/widgets/kira/kira_list/filters/filters_bloc.dart';
 import 'package:miro/blocs/widgets/kira/kira_list/infinity_list/events/infinity_list_reached_bottom_event.dart';
@@ -58,6 +59,9 @@ class InfinityListBloc<T extends AListItem> extends AListBloc<T> {
       end: (lastPageIndex + 1) * singlePageSize,
     );
 
+    // Loading state was added only to ensure loading state is always emitted.
+    // In BLoC, if next state is recognized as the same as previous state, it will not be emitted.
+    emit(ListLoadingState());
     emit(ListLoadedState<T>(
       listItems: visibleListItems,
       lastPage: currentPageData.lastPageBool,

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -12,7 +12,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 # In iOS, build-name is used as CFBundleShortVersionString while build-number used as CFBundleVersion.
 # Read more about iOS versioning at
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
-version: 1.28.0
+version: 1.28.1
 
 environment:
   sdk: ">=3.1.3"


### PR DESCRIPTION
The purpose of this branch is to fix not refreshing favourite balance right after sending tokens. Additionally, it was noticed that on desktop view, adding balances to favourites is broken if there is one record, because emitting list with changed favourites by InfinityListBloc does not cause SliverInfinityList to reload. So this issue was also examined on this branch.

List of changes:
- added missing "forceRequestBool" parameter while calling initFavourites() in _mapListReloadEventToState() method in a_list_bloc.dart. It allowed refreshing balances by avoiding getting them from cache.
- added emit(ListLoadingState()) in _mapListUpdatedEventToState() method in infinity_list_bloc.dart, to ensure the SliverInfinityList is reloaded with each emit, and the favourites will be updated. However, this is not the optimal solution, it may be necessary to rebuild the lists to manage this issue properly. Details can be found in "unify-list_items" ticket on Trello.