### PR TITLE
Bugfix: Increased tappable TxInput area

### DIFF
--- a/lib/views/layout/drawer/kira_drawer.dart
+++ b/lib/views/layout/drawer/kira_drawer.dart
@@ -25,51 +25,41 @@ class _KiraDrawer extends State<KiraDrawer> {
 
   @override
   Widget build(BuildContext context) {
-    return GestureDetector(
-      onTap: () => _handleDrawerShadowTap(context),
-      child: PopScope(
-        onPopInvoked: (_) => _handlePopInvoked(),
-        child: SizedBox(
-          width: widget.width,
-          height: MediaQuery.of(context).size.height,
-          child: Drawer(
-            backgroundColor: DesignColors.background,
-            child: Container(
-              width: double.infinity,
-              height: double.infinity,
-              decoration: const BoxDecoration(
-                color: DesignColors.background,
-              ),
-              child: SingleChildScrollView(
-                child: Column(
-                  mainAxisSize: MainAxisSize.max,
-                  mainAxisAlignment: MainAxisAlignment.start,
-                  crossAxisAlignment: CrossAxisAlignment.start,
-                  children: <Widget>[
-                    DrawerAppBar(
-                      onClose: _handleDrawerClose,
-                      onPop: _handleDrawerPop,
-                    ),
-                    Padding(
-                      padding:
-                          ResponsiveWidget.isSmallScreen(context) ? const EdgeInsets.symmetric(horizontal: 20) : const EdgeInsets.symmetric(horizontal: 32),
-                      child: widget.child,
-                    ),
-                  ],
-                ),
+    return PopScope(
+      onPopInvoked: (_) => _handlePopInvoked(),
+      child: SizedBox(
+        width: widget.width,
+        height: MediaQuery.of(context).size.height,
+        child: Drawer(
+          backgroundColor: DesignColors.background,
+          child: Container(
+            width: double.infinity,
+            height: double.infinity,
+            decoration: const BoxDecoration(
+              color: DesignColors.background,
+            ),
+            child: SingleChildScrollView(
+              child: Column(
+                mainAxisSize: MainAxisSize.max,
+                mainAxisAlignment: MainAxisAlignment.start,
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: <Widget>[
+                  DrawerAppBar(
+                    onClose: _handleDrawerClose,
+                    onPop: _handleDrawerPop,
+                  ),
+                  Padding(
+                    padding:
+                        ResponsiveWidget.isSmallScreen(context) ? const EdgeInsets.symmetric(horizontal: 20) : const EdgeInsets.symmetric(horizontal: 32),
+                    child: widget.child,
+                  ),
+                ],
               ),
             ),
           ),
         ),
       ),
     );
-  }
-
-  void _handleDrawerShadowTap(BuildContext context) {
-    FocusScopeNode isFocused = FocusScope.of(context);
-    if (!isFocused.hasPrimaryFocus) {
-      isFocused.unfocus();
-    }
   }
 
   Future<void> _handlePopInvoked() async {

--- a/lib/views/layout/scaffold/kira_scaffold.dart
+++ b/lib/views/layout/scaffold/kira_scaffold.dart
@@ -58,14 +58,11 @@ class _KiraScaffold extends State<KiraScaffold> {
       drawerEnableOpenDragGesture: false,
       endDrawerEnableOpenDragGesture: false,
       endDrawer: widget.endDrawer,
-      body: GestureDetector(
-        onTap: () => _handleActionLayoutFocus(context),
-        child: KiraBackground(
-          child: ResponsiveWidget(
-            largeScreen: kiraScaffoldDesktop,
-            mediumScreen: kiraScaffoldDesktop,
-            smallScreen: kiraScaffoldMobile,
-          ),
+      body: KiraBackground(
+        child: ResponsiveWidget(
+          largeScreen: kiraScaffoldDesktop,
+          mediumScreen: kiraScaffoldDesktop,
+          smallScreen: kiraScaffoldMobile,
         ),
       ),
     );
@@ -85,12 +82,5 @@ class _KiraScaffold extends State<KiraScaffold> {
 
   void closeEndDrawer() {
     drawerCubit.closeDrawer(scaffoldKey);
-  }
-
-  void _handleActionLayoutFocus(BuildContext context) {
-    FocusScopeNode isFocused = FocusScope.of(context);
-    if (!isFocused.hasPrimaryFocus) {
-      isFocused.unfocus();
-    }
   }
 }

--- a/lib/views/pages/transactions/msg_forms/ir_msg_register_record_form/ir_msg_register_record_form.dart
+++ b/lib/views/pages/transactions/msg_forms/ir_msg_register_record_form/ir_msg_register_record_form.dart
@@ -77,7 +77,8 @@ class _IRMsgRegisterRecordForm extends State<IRMsgRegisterRecordForm> {
               minHeight: 60,
               maxHeight: const ResponsiveValue<double>(largeScreen: 120, smallScreen: 94).get(context),
             ),
-            child: TxTextField(
+            builderWithFocus: (FocusNode focusNode) => TxTextField(
+              focusNode: focusNode,
               label: S.of(context).irTxHintKey,
               disabled: widget.irKeyEditableBool == false,
               textEditingController: identityKeyTextEditingController,
@@ -91,19 +92,20 @@ class _IRMsgRegisterRecordForm extends State<IRMsgRegisterRecordForm> {
           const SizedBox(height: 14),
           TxInputWrapper(
             boxConstraints: BoxConstraints(
-                minHeight: 60,
-                maxHeight: const ResponsiveValue<double>(largeScreen: 200, smallScreen: 125).get(context),
-              ),
-              child: TxTextField(
-                label: S.of(context).irTxHintValue,
-                maxLength: widget.irValueMaxLength,
-                textEditingController: identityValueTextEditingController,
-                inputFormatters: <TextInputFormatter>[
-                  FilteringTextInputFormatter.allow(StringUtils.irValueRegExp),
-                ],
-                onChanged: _handleValueChanged,
-              ),
+              minHeight: 60,
+              maxHeight: const ResponsiveValue<double>(largeScreen: 200, smallScreen: 125).get(context),
             ),
+            builderWithFocus: (FocusNode focusNode) => TxTextField(
+              focusNode: focusNode,
+              label: S.of(context).irTxHintValue,
+              maxLength: widget.irValueMaxLength,
+              textEditingController: identityValueTextEditingController,
+              inputFormatters: <TextInputFormatter>[
+                FilteringTextInputFormatter.allow(StringUtils.irValueRegExp),
+              ],
+              onChanged: _handleValueChanged,
+            ),
+          ),
         ],
       ),
     );

--- a/lib/views/widgets/transactions/memo_text_field/memo_text_field.dart
+++ b/lib/views/widgets/transactions/memo_text_field/memo_text_field.dart
@@ -48,9 +48,10 @@ class _MemoTextField extends State<MemoTextField> {
   Widget build(BuildContext context) {
     return TxInputWrapper(
       padding: const EdgeInsets.only(left: 16, right: 16, bottom: 16, top: 20),
-      child: Column(
+      builderWithFocus: (FocusNode focusNode) => Column(
         children: <Widget>[
           TxTextField(
+            focusNode: focusNode,
             textEditingController: widget.memoTextEditingController,
             label: widget.label,
             maxLines: widget.maxLines,

--- a/lib/views/widgets/transactions/token_form/token_amount_text_field/token_amount_text_field.dart
+++ b/lib/views/widgets/transactions/token_form/token_amount_text_field/token_amount_text_field.dart
@@ -1,16 +1,11 @@
 import 'package:flutter/material.dart';
-import 'package:flutter/services.dart';
-import 'package:flutter_bloc/flutter_bloc.dart';
-import 'package:miro/blocs/widgets/transactions/token_form/token_form_cubit.dart';
 import 'package:miro/shared/models/tokens/token_denomination_model.dart';
-import 'package:miro/shared/utils/transactions/tx_utils.dart';
 import 'package:miro/views/widgets/transactions/token_form/token_amount_text_field/token_amount_text_field_actions.dart';
-import 'package:miro/views/widgets/transactions/token_form/token_amount_text_field/token_amount_text_input_formatter.dart';
+import 'package:miro/views/widgets/transactions/token_form/token_amount_text_field/token_amount_text_field_content.dart';
 import 'package:miro/views/widgets/transactions/tx_input_static_label.dart';
 import 'package:miro/views/widgets/transactions/tx_input_wrapper.dart';
-import 'package:miro/views/widgets/transactions/tx_text_field.dart';
 
-class TokenAmountTextField extends StatefulWidget {
+class TokenAmountTextField extends StatelessWidget {
   final bool disabledBool;
   final bool errorExistsBool;
   final String label;
@@ -27,77 +22,35 @@ class TokenAmountTextField extends StatefulWidget {
   }) : super(key: key);
 
   @override
-  State<StatefulWidget> createState() => _TokenAmountTextField();
-}
-
-class _TokenAmountTextField extends State<TokenAmountTextField> {
-  final FocusNode focusNode = FocusNode();
-
-  @override
-  void initState() {
-    super.initState();
-    widget.textEditingController.addListener(_handleTextFieldChanged);
-    focusNode.addListener(_handleFocusChanged);
-  }
-
-  @override
-  void dispose() {
-    widget.textEditingController.removeListener(_handleTextFieldChanged);
-    focusNode.dispose();
-    super.dispose();
-  }
-
-  @override
   Widget build(BuildContext context) {
-    bool disabledBool = widget.disabledBool || widget.tokenDenominationModel == null;
+    bool correctDisabledBool = disabledBool || tokenDenominationModel == null;
 
     return Column(
       children: <Widget>[
         TxInputWrapper(
-          disabled: disabledBool,
+          disabled: correctDisabledBool,
           height: 80,
-          hasErrors: widget.errorExistsBool,
-          child: SizedBox(
+          hasErrors: errorExistsBool,
+          builderWithFocus: (FocusNode focusNode) => SizedBox(
             height: double.infinity,
             child: Center(
               child: TxInputStaticLabel(
-                label: widget.label,
+                label: label,
                 contentPadding: const EdgeInsets.only(top: 9, bottom: 5),
-                child: TxTextField(
-                  maxLines: 1,
+                child: TokenAmountTextFieldContent(
+                  disabledBool: correctDisabledBool,
+                  label: label,
+                  textEditingController: textEditingController,
+                  tokenDenominationModel: tokenDenominationModel,
                   focusNode: focusNode,
-                  hasErrors: widget.errorExistsBool,
-                  disabled: disabledBool,
-                  textEditingController: widget.textEditingController,
-                  inputFormatters: <TextInputFormatter>[
-                    TokenAmountTextInputFormatter(tokenDenominationModel: widget.tokenDenominationModel),
-                  ],
-                  onChanged: (_) => _handleTextFieldChanged(),
+                  errorExistsBool: errorExistsBool,
                 ),
               ),
             ),
           ),
         ),
-        TokenAmountTextFieldActions(disabled: disabledBool),
+        TokenAmountTextFieldActions(disabled: correctDisabledBool),
       ],
     );
-  }
-
-  void _handleTextFieldChanged() {
-    String text = widget.textEditingController.text;
-    BlocProvider.of<TokenFormCubit>(context).notifyTokenAmountTextChanged(text);
-  }
-
-  void _handleFocusChanged() {
-    bool focusedBool = focusNode.hasFocus;
-    String text = widget.textEditingController.text;
-    String displayedAmount = TxUtils.buildAmountString(text, widget.tokenDenominationModel);
-    if (focusedBool == false && text.isEmpty) {
-      widget.textEditingController.text = '0';
-    } else if (focusedBool == false) {
-      widget.textEditingController.text = displayedAmount;
-    } else if (focusedBool && text == '0') {
-      widget.textEditingController.text = '';
-    }
   }
 }

--- a/lib/views/widgets/transactions/token_form/token_amount_text_field/token_amount_text_field_content.dart
+++ b/lib/views/widgets/transactions/token_form/token_amount_text_field/token_amount_text_field_content.dart
@@ -1,0 +1,79 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:miro/blocs/widgets/transactions/token_form/token_form_cubit.dart';
+import 'package:miro/shared/models/tokens/token_denomination_model.dart';
+import 'package:miro/shared/utils/transactions/tx_utils.dart';
+import 'package:miro/views/widgets/transactions/token_form/token_amount_text_field/token_amount_text_input_formatter.dart';
+import 'package:miro/views/widgets/transactions/tx_text_field.dart';
+
+class TokenAmountTextFieldContent extends StatefulWidget {
+  final bool disabledBool;
+  final String label;
+  final TextEditingController textEditingController;
+  final TokenDenominationModel? tokenDenominationModel;
+  final FocusNode focusNode;
+  final bool errorExistsBool;
+
+  const TokenAmountTextFieldContent({
+    required this.disabledBool,
+    required this.label,
+    required this.textEditingController,
+    required this.tokenDenominationModel,
+    required this.focusNode,
+    this.errorExistsBool = false,
+    super.key,
+  });
+
+  @override
+  State<TokenAmountTextFieldContent> createState() => _TokenAmountTextFieldContentState();
+}
+
+class _TokenAmountTextFieldContentState extends State<TokenAmountTextFieldContent> {
+  @override
+  void initState() {
+    super.initState();
+    widget.textEditingController.addListener(_handleTextFieldChanged);
+    widget.focusNode.addListener(_handleFocusChanged);
+  }
+
+  @override
+  void dispose() {
+    widget.textEditingController.removeListener(_handleTextFieldChanged);
+    widget.focusNode.removeListener(_handleFocusChanged);
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return TxTextField(
+      maxLines: 1,
+      focusNode: widget.focusNode,
+      hasErrors: widget.errorExistsBool,
+      disabled: widget.disabledBool,
+      textEditingController: widget.textEditingController,
+      inputFormatters: <TextInputFormatter>[
+        TokenAmountTextInputFormatter(tokenDenominationModel: widget.tokenDenominationModel),
+      ],
+      onChanged: (_) => _handleTextFieldChanged(),
+    );
+  }
+
+  void _handleTextFieldChanged() {
+    String text = widget.textEditingController.text;
+    BlocProvider.of<TokenFormCubit>(context).notifyTokenAmountTextChanged(text);
+  }
+
+  void _handleFocusChanged() {
+    bool focusedBool = widget.focusNode.hasFocus;
+    String text = widget.textEditingController.text;
+    String displayedAmount = TxUtils.buildAmountString(text, widget.tokenDenominationModel);
+    if (focusedBool == false && text.isEmpty) {
+      widget.textEditingController.text = '0';
+    } else if (focusedBool == false) {
+      widget.textEditingController.text = displayedAmount;
+    } else if (focusedBool && text == '0') {
+      widget.textEditingController.text = '';
+    }
+  }
+}

--- a/lib/views/widgets/transactions/tx_input_wrapper.dart
+++ b/lib/views/widgets/transactions/tx_input_wrapper.dart
@@ -1,8 +1,9 @@
 import 'package:flutter/material.dart';
 import 'package:miro/config/theme/design_colors.dart';
 
-class TxInputWrapper extends StatelessWidget {
-  final Widget child;
+class TxInputWrapper extends StatefulWidget {
+  final Widget Function(FocusNode)? builderWithFocus;
+  final Widget? child;
   final bool disabled;
   final bool hasErrors;
   final double? height;
@@ -10,32 +11,50 @@ class TxInputWrapper extends StatelessWidget {
   final EdgeInsets padding;
 
   const TxInputWrapper({
-    required this.child,
+    this.builderWithFocus,
+    this.child,
     this.disabled = false,
     this.hasErrors = false,
     this.height,
     this.boxConstraints,
     this.padding = const EdgeInsets.all(16),
     Key? key,
-  }) : super(key: key);
+  })  : assert(builderWithFocus != null || child != null, 'Either [builderWithFocus] or [child] must be provided.'),
+        super(key: key);
+
+  @override
+  State<TxInputWrapper> createState() => _TxInputWrapperState();
+}
+
+class _TxInputWrapperState extends State<TxInputWrapper> {
+  final FocusNode focusNode = FocusNode();
+
+  @override
+  void dispose() {
+    focusNode.dispose();
+    super.dispose();
+  }
 
   @override
   Widget build(BuildContext context) {
-    return Opacity(
-      opacity: disabled ? 0.5 : 1,
-      child: Container(
-        height: height,
-        constraints: boxConstraints,
-        padding: padding,
-        decoration: BoxDecoration(
-          color: DesignColors.background,
-          borderRadius: BorderRadius.circular(8),
-          border: Border.all(
-            color: hasErrors ? DesignColors.redStatus1 : Colors.transparent,
-            width: 1,
+    return GestureDetector(
+      onTap: widget.builderWithFocus != null ? focusNode.requestFocus : null,
+      child: Opacity(
+        opacity: widget.disabled ? 0.5 : 1,
+        child: Container(
+          height: widget.height,
+          constraints: widget.boxConstraints,
+          padding: widget.padding,
+          decoration: BoxDecoration(
+            color: DesignColors.background,
+            borderRadius: BorderRadius.circular(8),
+            border: Border.all(
+              color: widget.hasErrors ? DesignColors.redStatus1 : Colors.transparent,
+              width: 1,
+            ),
           ),
+          child: widget.builderWithFocus != null ? widget.builderWithFocus!(focusNode) : widget.child,
         ),
-        child: child,
       ),
     );
   }

--- a/lib/views/widgets/transactions/tx_validator_preview.dart
+++ b/lib/views/widgets/transactions/tx_validator_preview.dart
@@ -17,7 +17,7 @@ class TxValidatorPreview extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return TxInputWrapper(
-      child: Row(
+      builderWithFocus: (FocusNode focusNode) => Row(
         crossAxisAlignment: CrossAxisAlignment.center,
         children: <Widget>[
           KiraIdentityAvatar(
@@ -29,6 +29,7 @@ class TxValidatorPreview extends StatelessWidget {
             child: Align(
               alignment: Alignment.centerLeft,
               child: TxTextField(
+                focusNode: focusNode,
                 disabled: true,
                 maxLines: 1,
                 label: label,

--- a/lib/views/widgets/transactions/wallet_address_text_field.dart
+++ b/lib/views/widgets/transactions/wallet_address_text_field.dart
@@ -56,7 +56,7 @@ class _WalletAddressTextField extends State<WalletAddressTextField> {
           children: <Widget>[
             TxInputWrapper(
               hasErrors: field.hasError,
-              child: Row(
+              builderWithFocus: (FocusNode focusNode) => Row(
                 crossAxisAlignment: CrossAxisAlignment.center,
                 children: <Widget>[
                   ValueListenableBuilder<WalletAddress?>(
@@ -73,6 +73,7 @@ class _WalletAddressTextField extends State<WalletAddressTextField> {
                     child: Align(
                       alignment: Alignment.centerLeft,
                       child: TxTextField(
+                        focusNode: focusNode,
                         disabled: widget.disabledBool,
                         maxLines: 1,
                         hasErrors: field.hasError,

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: miro
 description: KIRA blockchain explorer
 publish_to: 'none'
-version: 1.29.1
+version: 1.30.0
 
 environment:
   sdk: "3.2.6"
@@ -206,6 +206,11 @@ dev_dependencies:
 
   flutter_test:
     sdk: flutter
+
+
+dependency_overrides:
+  #  TODO(Mykyta): a temporary fix for flutter_dropzone_platform_interface issue with wrong version. It should be fixed by package's owner, and then recheck it locally.
+  flutter_dropzone_platform_interface: 2.0.6
 
 flutter:
   uses-material-design: true


### PR DESCRIPTION
Increased tappable area of TxInputWrapper. Made requested focus once user tapped on borders of the text field. Before this fix, user must have tapped at the text line to activate field which has a tiny height comparing to the whole field.

List of changes:
- added optional [builderWithFocus] to TxInputWrapper which gives correct node of the whole field to the text widget
- removed excess GestureDetector with unfocus() at kira_drawer.dart and kira_scaffold.dart, because they are useless
- unrelated with the branch's specific domain: added a temporary fix for `flutter_dropzone_platform_interface` issue with wrong version. It should be fixed by package's owner, and then rechecked locally.